### PR TITLE
Include newbase library headers with correct notation

### DIFF
--- a/smartmet-library-smarttools.spec
+++ b/smartmet-library-smarttools.spec
@@ -56,6 +56,9 @@ FMI smarttools development files
 
 
 %changelog
+* Upcoming
+- Include newbase library headers with correct notation
+
 * Fri Feb 10 2017 Mika Heiskanen <mika.heiskanen@fmi.fi> - 17.2.10-1.fmi
 - Merged SmartMet Editor changes
 

--- a/smarttools/NFmiAreaMaskInfo.h
+++ b/smarttools/NFmiAreaMaskInfo.h
@@ -7,10 +7,10 @@
 //
 //**********************************************************
 
-#include <NFmiAreaMask.h>
-#include <NFmiDataIdent.h>
-#include <NFmiCalculationCondition.h>
-#include <NFmiPoint.h>
+#include <newbase/NFmiAreaMask.h>
+#include <newbase/NFmiDataIdent.h>
+#include <newbase/NFmiCalculationCondition.h>
+#include <newbase/NFmiPoint.h>
 #include "NFmiSoundingIndexCalculator.h"
 
 class NFmiLevel;

--- a/smarttools/NFmiAreaMaskSectionInfo.h
+++ b/smarttools/NFmiAreaMaskSectionInfo.h
@@ -9,7 +9,7 @@
 // IF(T>2) tai IF(T>2 && P<1012) jne.
 //**********************************************************
 
-#include <NFmiDataMatrix.h>  // täältä tulee myös checkedVector
+#include <newbase/NFmiDataMatrix.h>  // täältä tulee myös checkedVector
 #include <boost/shared_ptr.hpp>
 #include <string>
 

--- a/smarttools/NFmiAviationStationInfoSystem.h
+++ b/smarttools/NFmiAviationStationInfoSystem.h
@@ -8,7 +8,7 @@
 #ifndef AVIATIONSTATION_H
 #define AVIATIONSTATION_H
 
-#include <NFmiStation.h>
+#include <newbase/NFmiStation.h>
 
 #include <string>
 #include <map>

--- a/smarttools/NFmiCalculationConstantValue.h
+++ b/smarttools/NFmiCalculationConstantValue.h
@@ -7,8 +7,8 @@
 //
 //**********************************************************
 
-#include <NFmiAreaMaskImpl.h>
-#include <NFmiInfoAreaMask.h>
+#include <newbase/NFmiAreaMaskImpl.h>
+#include <newbase/NFmiInfoAreaMask.h>
 #include <boost/shared_ptr.hpp>
 
 #ifdef FMI_SUPPORT_STATION_DATA_SMARTTOOL

--- a/smarttools/NFmiColor.h
+++ b/smarttools/NFmiColor.h
@@ -8,8 +8,9 @@
 #ifndef NFMICOLOR_H
 #define NFMICOLOR_H
 
-#include "NFmiGlobals.h"
 #include "FmiColorTypes.h"
+
+#include <newbase/NFmiGlobals.h>
 #include <iostream>
 
 class NFmiColor

--- a/smarttools/NFmiDataStoringHelpers.h
+++ b/smarttools/NFmiDataStoringHelpers.h
@@ -7,9 +7,9 @@
 #ifndef NFMIDATASTORINGHELPERS_H
 #define NFMIDATASTORINGHELPERS_H
 
-#include <NFmiString.h>
-#include <NFmiStringTools.h>
-#include <NFmiTimeBag.h>
+#include <newbase/NFmiString.h>
+#include <newbase/NFmiStringTools.h>
+#include <newbase/NFmiTimeBag.h>
 
 #include <iterator>
 #include <vector>

--- a/smarttools/NFmiDictionaryFunction.h
+++ b/smarttools/NFmiDictionaryFunction.h
@@ -7,7 +7,7 @@
 #ifndef NFMIDICTIONARYFUNCTION_H
 #define NFMIDICTIONARYFUNCTION_H
 
-#include <NFmiSettings.h>
+#include <newbase/NFmiSettings.h>
 
 // HUOM! Tämä on kopio NFmiEditMapGeneralDataDoc-luokan metodista, kun en voinut antaa tänne
 // dokumenttia

--- a/smarttools/NFmiDrawParam.h
+++ b/smarttools/NFmiDrawParam.h
@@ -34,13 +34,13 @@
 #include "NFmiColor.h"
 #include "NFmiMetEditorTypes.h"
 
-#include <NFmiParameterName.h>
-#include <NFmiDataIdent.h>
-#include <NFmiPoint.h>
-#include <NFmiLevel.h>
-#include <NFmiInfoData.h>
-#include <NFmiDataMatrix.h>  // täältä tulee myös checkedVector
-#include <NFmiMetTime.h>
+#include <newbase/NFmiParameterName.h>
+#include <newbase/NFmiDataIdent.h>
+#include <newbase/NFmiPoint.h>
+#include <newbase/NFmiLevel.h>
+#include <newbase/NFmiInfoData.h>
+#include <newbase/NFmiDataMatrix.h>  // täältä tulee myös checkedVector
+#include <newbase/NFmiMetTime.h>
 #include <boost/shared_ptr.hpp>
 
 class NFmiDrawingEnvironment;

--- a/smarttools/NFmiDrawParamList.h
+++ b/smarttools/NFmiDrawParamList.h
@@ -33,8 +33,8 @@
 #define NFMIDRAWPARAMLIST_H
 
 #include "NFmiSortedPtrList.h"
-#include <NFmiDataMatrix.h>
-#include <NFmiInfoData.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiInfoData.h>
 #include "NFmiDrawParam.h"
 #include <boost/shared_ptr.hpp>
 #include <list>

--- a/smarttools/NFmiExtraMacroParamData.cpp
+++ b/smarttools/NFmiExtraMacroParamData.cpp
@@ -1,5 +1,5 @@
 #include "NFmiExtraMacroParamData.h"
-#include "NFmiFastQueryInfo.h"
+#include <newbase/NFmiFastQueryInfo.h>
 #include "NFmiInfoOrganizer.h"
 
 #include <boost/math/special_functions/round.hpp>

--- a/smarttools/NFmiExtraMacroParamData.h
+++ b/smarttools/NFmiExtraMacroParamData.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "NFmiProducer.h"
-#include "NFmiLevelType.h"
-#include "NFmiDataMatrix.h"
+#include <newbase/NFmiProducer.h>
+#include <newbase/NFmiLevelType.h>
+#include <newbase/NFmiDataMatrix.h>
 
 #include "boost/shared_ptr.hpp"
 

--- a/smarttools/NFmiGridPointCache.h
+++ b/smarttools/NFmiGridPointCache.h
@@ -8,8 +8,8 @@
 #ifndef NFMIGRIDPOINTCACHE_H
 #define NFMIGRIDPOINTCACHE_H
 
-#include <NFmiDataMatrix.h>
-#include <NFmiPoint.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiPoint.h>
 
 #include <string>
 #include <map>

--- a/smarttools/NFmiHarmonizerBookKeepingData.h
+++ b/smarttools/NFmiHarmonizerBookKeepingData.h
@@ -1,8 +1,8 @@
 #ifndef NFMIHARMONIZERBOOKKEEPINGDATA_H
 #define NFMIHARMONIZERBOOKKEEPINGDATA_H
 
-#include <NFmiMetTime.h>
-#include <NFmiParamBag.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiParamBag.h>
 #include <set>
 
 // smartinfon pitää pitää kirjaa harmonisaattoriin liittyvistä asioista

--- a/smarttools/NFmiHelpDataInfo.h
+++ b/smarttools/NFmiHelpDataInfo.h
@@ -10,10 +10,10 @@
 #ifndef NFMIHELPDATAINFO_H
 #define NFMIHELPDATAINFO_H
 
-#include <NFmiInfoData.h>
-#include <NFmiDataIdent.h>
-#include <NFmiDataMatrix.h>
-#include <NFmiProducerName.h>
+#include <newbase/NFmiInfoData.h>
+#include <newbase/NFmiDataIdent.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiProducerName.h>
 
 #include <boost/shared_ptr.hpp>
 

--- a/smarttools/NFmiInfoAreaMaskOccurrance.cpp
+++ b/smarttools/NFmiInfoAreaMaskOccurrance.cpp
@@ -1,8 +1,8 @@
 
 #include "NFmiInfoAreaMaskOccurrance.h"
-#include "NFmiFastQueryInfo.h"
+#include <newbase/NFmiFastQueryInfo.h>
 #include "NFmiDrawParam.h"
-#include "NFmiProducerName.h"
+#include <newbase/NFmiProducerName.h>
 #include "NFmiSmartInfo.h"
 
 // **********************************************************

--- a/smarttools/NFmiInfoAreaMaskOccurrance.h
+++ b/smarttools/NFmiInfoAreaMaskOccurrance.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "NFmiInfoAreaMask.h"
+#include <newbase/NFmiInfoAreaMask.h>
 
 class NFmiDrawParam;
 

--- a/smarttools/NFmiInfoAreaMaskSoundingIndex.h
+++ b/smarttools/NFmiInfoAreaMaskSoundingIndex.h
@@ -8,7 +8,7 @@
 #ifndef NFMIINFOAREAMASKSOUNDINGINDEX_H
 #define NFMIINFOAREAMASKSOUNDINGINDEX_H
 
-#include <NFmiInfoAreaMask.h>
+#include <newbase/NFmiInfoAreaMask.h>
 #include "NFmiSoundingIndexCalculator.h"
 
 class NFmiFastQueryInfo;

--- a/smarttools/NFmiInfoOrganizer.h
+++ b/smarttools/NFmiInfoOrganizer.h
@@ -22,11 +22,11 @@
 // TODO: keksi parempi nimi tai muuta lopuksi NFmiInfoOrganizer-nimiseksi ja
 // tuhoa alkuperäinen luokka.
 
-#include <NFmiPoint.h>
-#include <NFmiDataMatrix.h>
-#include <NFmiInfoData.h>
-#include <NFmiParamBag.h>
-#include <NFmiProducerName.h>
+#include <newbase/NFmiPoint.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiInfoData.h>
+#include <newbase/NFmiParamBag.h>
+#include <newbase/NFmiProducerName.h>
 #include <boost/shared_ptr.hpp>
 #include <map>
 

--- a/smarttools/NFmiMultiLevelMask.h
+++ b/smarttools/NFmiMultiLevelMask.h
@@ -35,7 +35,7 @@
 #ifndef NFMIMULTILEVELMASK_H
 #define NFMIMULTILEVELMASK_H
 
-#include <NFmiBitMask.h>
+#include <newbase/NFmiBitMask.h>
 
 class NFmiRect;
 

--- a/smarttools/NFmiOwnerInfo.h
+++ b/smarttools/NFmiOwnerInfo.h
@@ -7,7 +7,7 @@
 // ns. InfoOrganizer-luokkaan talteen, mistä eri datojen infoja pyydetään.
 // TODO: Keksi luokalle parempi nimi.
 
-#include <NFmiFastQueryInfo.h>
+#include <newbase/NFmiFastQueryInfo.h>
 #include <boost/shared_ptr.hpp>
 
 class NFmiOwnerInfo : public NFmiFastQueryInfo

--- a/smarttools/NFmiProducerSystem.h
+++ b/smarttools/NFmiProducerSystem.h
@@ -12,9 +12,9 @@
 #ifndef NFMIPRODUCERSYSTEM_H
 #define NFMIPRODUCERSYSTEM_H
 
-#include <NFmiProducer.h>
-#include <NFmiProducerName.h>
-#include <NFmiInfoData.h>
+#include <newbase/NFmiProducer.h>
+#include <newbase/NFmiProducerName.h>
+#include <newbase/NFmiInfoData.h>
 #include <string>
 #include <vector>
 

--- a/smarttools/NFmiQueryDataKeeper.h
+++ b/smarttools/NFmiQueryDataKeeper.h
@@ -1,10 +1,10 @@
 #ifndef NFMIQUERYDATAKEEPER_H
 #define NFMIQUERYDATAKEEPER_H
 
-#include <NFmiMilliSecondTimer.h>
-#include <NFmiDataMatrix.h>
-#include <NFmiMetTime.h>
-#include <NFmiInfoData.h>
+#include <newbase/NFmiMilliSecondTimer.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiInfoData.h>
 #include <boost/shared_ptr.hpp>
 #include <list>
 #include <set>

--- a/smarttools/NFmiRawTempStationInfoSystem.h
+++ b/smarttools/NFmiRawTempStationInfoSystem.h
@@ -14,8 +14,8 @@
 #ifndef NFMIRAWTEMPSTATIONINFOSYSTEM_H
 #define NFMIRAWTEMPSTATIONINFOSYSTEM_H
 
-#include <NFmiHPlaceDescriptor.h>
-#include <NFmiStation.h>
+#include <newbase/NFmiHPlaceDescriptor.h>
+#include <newbase/NFmiStation.h>
 
 class NFmiRawTempStationInfoSystem
 {

--- a/smarttools/NFmiSmartToolCalculation.h
+++ b/smarttools/NFmiSmartToolCalculation.h
@@ -8,10 +8,10 @@
 // Tämä luokka hoitaa yhden laskurivin esim. T = T + 1
 //**********************************************************
 
-#include <NFmiAreaMask.h>
-#include <NFmiPoint.h>
-#include <NFmiDataMatrix.h>
-#include <NFmiMetTime.h>
+#include <newbase/NFmiAreaMask.h>
+#include <newbase/NFmiPoint.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiMetTime.h>
 #include <boost/shared_ptr.hpp>
 #include <string>
 

--- a/smarttools/NFmiSmartToolCalculationInfo.h
+++ b/smarttools/NFmiSmartToolCalculationInfo.h
@@ -15,7 +15,7 @@
 // operandeja (n kpl) ja operaatioita (n-1 kpl).
 //**********************************************************
 
-#include <NFmiDataMatrix.h>
+#include <newbase/NFmiDataMatrix.h>
 #include <boost/shared_ptr.hpp>
 #include <string>
 

--- a/smarttools/NFmiSmartToolCalculationSection.h
+++ b/smarttools/NFmiSmartToolCalculationSection.h
@@ -11,8 +11,8 @@
 // P = P + 2
 //**********************************************************
 
-#include <NFmiDataMatrix.h>
-#include <NFmiAreaMask.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiAreaMask.h>
 #include <boost/shared_ptr.hpp>
 
 class NFmiPoint;

--- a/smarttools/NFmiSmartToolCalculationSectionInfo.h
+++ b/smarttools/NFmiSmartToolCalculationSectionInfo.h
@@ -13,7 +13,7 @@
 // Yksi rivi on aina yksi lasku ja laskussa pitää olla sijoitus johonkin parametriin (=).
 //**********************************************************
 
-#include <NFmiDataMatrix.h>
+#include <newbase/NFmiDataMatrix.h>
 #include <boost/shared_ptr.hpp>
 #include <set>
 

--- a/smarttools/NFmiSmartToolInfo.h
+++ b/smarttools/NFmiSmartToolInfo.h
@@ -8,7 +8,7 @@
  *
  */
 
-#include <NFmiDataMatrix.h>
+#include <newbase/NFmiDataMatrix.h>
 #include <string>
 
 class NFmiSmartToolInfo

--- a/smarttools/NFmiSmartToolIntepreter.h
+++ b/smarttools/NFmiSmartToolIntepreter.h
@@ -27,13 +27,13 @@
 // jälkeen pitää tulla calculationSection.
 //**********************************************************
 
-#include <NFmiParameterName.h>
-#include <NFmiProducerName.h>
-#include <NFmiAreaMask.h>
-#include <NFmiProducer.h>
-#include <NFmiLevelType.h>
-#include <NFmiParamBag.h>
-#include <NFmiDataMatrix.h>
+#include <newbase/NFmiParameterName.h>
+#include <newbase/NFmiProducerName.h>
+#include <newbase/NFmiAreaMask.h>
+#include <newbase/NFmiProducer.h>
+#include <newbase/NFmiLevelType.h>
+#include <newbase/NFmiParamBag.h>
+#include <newbase/NFmiDataMatrix.h>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/tuple/tuple.hpp>

--- a/smarttools/NFmiSmartToolModifier.h
+++ b/smarttools/NFmiSmartToolModifier.h
@@ -18,11 +18,11 @@
 // laskut suoritetaan.
 //**********************************************************
 
-#include <NFmiParamBag.h>
-#include <NFmiDataMatrix.h>
-#include <NFmiInfoData.h>
-#include <NFmiLevelType.h>
-#include <NFmiAreaMask.h>
+#include <newbase/NFmiParamBag.h>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiInfoData.h>
+#include <newbase/NFmiLevelType.h>
+#include <newbase/NFmiAreaMask.h>
 #include <boost/shared_ptr.hpp>
 #include <string>
 

--- a/smarttools/NFmiSmartToolUtil.h
+++ b/smarttools/NFmiSmartToolUtil.h
@@ -16,7 +16,7 @@
 #ifndef NFMISMARTTOOLUTIL_H
 #define NFMISMARTTOOLUTIL_H
 
-#include <NFmiDataMatrix.h>
+#include <newbase/NFmiDataMatrix.h>
 #include <string>
 
 class NFmiQueryData;

--- a/smarttools/NFmiSortedPtrList.h
+++ b/smarttools/NFmiSortedPtrList.h
@@ -29,7 +29,7 @@
 #ifndef NFMISORTEDPTRLIST_H
 #define NFMISORTEDPTRLIST_H
 
-#include <NFmiPtrList.h>
+#include <newbase/NFmiPtrList.h>
 
 template <class Type>
 class NFmiSortedPtrList : public NFmiPtrList<Type>

--- a/smarttools/NFmiSoundingData.h
+++ b/smarttools/NFmiSoundingData.h
@@ -10,9 +10,9 @@
 #ifndef NFMISOUNDINGDATA_H
 #define NFMISOUNDINGDATA_H
 
-#include <NFmiMetTime.h>
-#include <NFmiLocation.h>
-#include <NFmiParameterName.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiLocation.h>
+#include <newbase/NFmiParameterName.h>
 #include <boost/shared_ptr.hpp>
 #include <deque>
 

--- a/smarttools/NFmiSoundingDataOpt1.h
+++ b/smarttools/NFmiSoundingDataOpt1.h
@@ -12,9 +12,9 @@
 
 #include "NFmiSoundingData.h"
 
-#include <NFmiMetTime.h>
-#include <NFmiLocation.h>
-#include <NFmiParameterName.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiLocation.h>
+#include <newbase/NFmiParameterName.h>
 
 #include <deque>
 #include <unordered_map>

--- a/smarttools/NFmiSoundingFunctions.h
+++ b/smarttools/NFmiSoundingFunctions.h
@@ -11,7 +11,7 @@
 #ifndef NFMISOUNDINGFUNCTIONS_H
 #define NFMISOUNDINGFUNCTIONS_H
 
-#include "NFmiGlobals.h"
+#include <newbase/NFmiGlobals.h>
 #include <cmath>
 
 namespace NFmiSoundingFunctions

--- a/smarttools/NFmiTEMPCode.h
+++ b/smarttools/NFmiTEMPCode.h
@@ -2,8 +2,8 @@
 #ifndef NFMITEMPCODE_H
 #define NFMITEMPCODE_H
 
-#include <NFmiMetTime.h>
-#include <NFmiStation.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiStation.h>
 
 #include <string>
 #include <vector>

--- a/smarttools/NFmiUndoableMultiLevelMask.h
+++ b/smarttools/NFmiUndoableMultiLevelMask.h
@@ -30,7 +30,7 @@
 #ifndef NFMIUNDOABLEMULTILEVELMASK_H
 #define NFMIUNDOABLEMULTILEVELMASK_H
 
-#include <NFmiPtrList.h>
+#include <newbase/NFmiPtrList.h>
 
 class NFmiMultiLevelMask;
 class NFmiBitMask;


### PR DESCRIPTION
An external library header must be included by using angle-brackets and
local headers by using quotation marks.

It is also more clear to add a path before header name if a file
included is from an external library. In this case it is newbase/.