### PR TITLE
Fix include notation of NFmiFastInfoUtils.h in NFmiStation2GridMask

### DIFF
--- a/smarttools/NFmiStation2GridMask.cpp
+++ b/smarttools/NFmiStation2GridMask.cpp
@@ -1,7 +1,7 @@
 #include "NFmiStation2GridMask.h"
 #include "NFmiDrawParam.h"
 #include "NFmiGriddingHelperInterface.h"
-#include "NFmiFastInfoUtils.h"
+#include <newbase/NFmiFastInfoUtils.h>
 #include <newbase/NFmiFastQueryInfo.h>
 
 // ****************************************************************************


### PR DESCRIPTION
The file is now part of newbase library. The change fixes the library compilation on Linux.