### PR TITLE
Run clang-format after the revert to default include order in clang 4.0.0

### DIFF
--- a/smartmet-library-smarttools.spec
+++ b/smartmet-library-smarttools.spec
@@ -56,6 +56,9 @@ FMI smarttools development files
 
 
 %changelog
+* Upcoming
+- Run clang-format after the revert to default include order in clang 4.0.0
+
 * Tue Apr  4 2017 Mika Heiskanen <mika.heiskanen@fmi.fi> - 17.4.4-1.fmi
 - Recompiled to use the latest newbase API
 

--- a/smarttools/FmiColorTypes.h
+++ b/smarttools/FmiColorTypes.h
@@ -14,4 +14,3 @@ typedef struct
 {
   FmiColorValue red, green, blue, alpha;
 } FmiRGBColor;
-

--- a/smarttools/NFmiAreaMaskInfo.cpp
+++ b/smarttools/NFmiAreaMaskInfo.cpp
@@ -77,10 +77,7 @@ NFmiAreaMaskInfo::NFmiAreaMaskInfo(const NFmiAreaMaskInfo &theOther)
 {
 }
 
-NFmiAreaMaskInfo::~NFmiAreaMaskInfo(void)
-{
-  delete itsLevel;
-}
+NFmiAreaMaskInfo::~NFmiAreaMaskInfo(void) { delete itsLevel; }
 
 void NFmiAreaMaskInfo::SetLevel(NFmiLevel *theLevel)
 {

--- a/smarttools/NFmiAreaMaskInfo.h
+++ b/smarttools/NFmiAreaMaskInfo.h
@@ -7,11 +7,11 @@
 //
 //**********************************************************
 
-#include <newbase/NFmiAreaMask.h>
-#include <newbase/NFmiDataIdent.h>
-#include <newbase/NFmiCalculationCondition.h>
-#include <newbase/NFmiPoint.h>
 #include "NFmiSoundingIndexCalculator.h"
+#include <newbase/NFmiAreaMask.h>
+#include <newbase/NFmiCalculationCondition.h>
+#include <newbase/NFmiDataIdent.h>
+#include <newbase/NFmiPoint.h>
 
 class NFmiLevel;
 
@@ -86,6 +86,7 @@ class NFmiAreaMaskInfo
   void SoundingParameter(FmiSoundingParameters newValue) { itsSoundingParameter = newValue; }
   int ModelRunIndex(void) const { return itsModelRunIndex; }
   void ModelRunIndex(int newValue) { itsModelRunIndex = newValue; }
+
  private:
   NFmiDataIdent itsDataIdent;
   bool fUseDefaultProducer;

--- a/smarttools/NFmiAreaMaskSectionInfo.cpp
+++ b/smarttools/NFmiAreaMaskSectionInfo.cpp
@@ -28,12 +28,8 @@
 //--------------------------------------------------------
 // Constructor/Destructor
 //--------------------------------------------------------
-NFmiAreaMaskSectionInfo::NFmiAreaMaskSectionInfo()
-{
-}
-NFmiAreaMaskSectionInfo::~NFmiAreaMaskSectionInfo()
-{
-}
+NFmiAreaMaskSectionInfo::NFmiAreaMaskSectionInfo() {}
+NFmiAreaMaskSectionInfo::~NFmiAreaMaskSectionInfo() {}
 
 boost::shared_ptr<NFmiAreaMaskInfo> NFmiAreaMaskSectionInfo::MaskInfo(int theIndex)
 {

--- a/smarttools/NFmiAreaMaskSectionInfo.h
+++ b/smarttools/NFmiAreaMaskSectionInfo.h
@@ -9,8 +9,8 @@
 // IF(T>2) tai IF(T>2 && P<1012) jne.
 //**********************************************************
 
-#include <newbase/NFmiDataMatrix.h>  // täältä tulee myös checkedVector
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiDataMatrix.h>  // täältä tulee myös checkedVector
 
 class NFmiAreaMaskInfo;
 
@@ -28,6 +28,7 @@ class NFmiAreaMaskSectionInfo
   }
   const std::string& GetCalculationText(void) { return itsCalculationText; }
   void SetCalculationText(const std::string& theText) { itsCalculationText = theText; }
+
  private:
   checkedVector<boost::shared_ptr<NFmiAreaMaskInfo> > itsAreaMaskInfoVector;
   std::string itsCalculationText;  // originaali teksti, mistä tämä lasku on tulkittu

--- a/smarttools/NFmiAviationStationInfoSystem.cpp
+++ b/smarttools/NFmiAviationStationInfoSystem.cpp
@@ -49,10 +49,8 @@ static bool GetAviationStationFromCsvString(const std::string &theStationStr,
   static long currentWmoIdCounter = 128000;
   if (theStationStr.size() > 2)
   {
-    if (theStationStr[0] == '#')
-      return false;
-    if (theStationStr[0] == '/' && theStationStr[1] == '/')
-      return false;
+    if (theStationStr[0] == '#') return false;
+    if (theStationStr[0] == '/' && theStationStr[1] == '/') return false;
 
     std::vector<std::string> stationParts = NFmiStringTools::Split(theStationStr, ",");
     if (stationParts.size() >= 30)
@@ -66,8 +64,7 @@ static bool GetAviationStationFromCsvString(const std::string &theStationStr,
       long wmoId = missingWmoId;
       double lat = -9999;
       double lon = -9999;
-      if (icaoStr.size() == 4)
-        icaoOk = true;
+      if (icaoStr.size() == 4) icaoOk = true;
       try
       {
         wmoId = NFmiStringTools::Convert<long>(stationParts[21]);
@@ -90,8 +87,7 @@ static bool GetAviationStationFromCsvString(const std::string &theStationStr,
       if (latlonOk && (fIcaoNeeded == false || (fIcaoNeeded && icaoOk)) &&
           (fWmoNeeded == false || (fWmoNeeded && wmoOk)))
       {
-        if (wmoId == missingWmoId)
-          wmoId = currentWmoIdCounter++;
+        if (wmoId == missingWmoId) wmoId = currentWmoIdCounter++;
         theStationOut.SetIdent(wmoId);
         theStationOut.SetLatitude(lat);
         theStationOut.SetLongitude(lon);
@@ -205,13 +201,11 @@ static double GetLatOrLon(const std::string &theLatOrLonStr, bool fDoLatitude)
   value += (NFmiStringTools::Convert<double>(minutesStr) / 60. * 100.) / 100.;
   if (fDoLatitude)
   {
-    if (orientationStr == "S")
-      value = -value;
+    if (orientationStr == "S") value = -value;
   }
   else
   {
-    if (orientationStr == "W")
-      value = -value;
+    if (orientationStr == "W") value = -value;
   }
   return value;
 }
@@ -246,10 +240,8 @@ static bool GetAviationStationFromWmoFlatTableString(const std::string &theStati
   {
     // HUOM! vaikka data formaatti ei tuekaan kommentteja, annetaan kommenttien tarkistus koodin
     // olla tässä varmuuden vuoksi
-    if (theStationStr[0] == '#')
-      return false;
-    if (theStationStr[0] == '/' && theStationStr[1] == '/')
-      return false;
+    if (theStationStr[0] == '#') return false;
+    if (theStationStr[0] == '/' && theStationStr[1] == '/') return false;
 
     std::vector<std::string> stationParts = NFmiStringTools::Split(theStationStr, "\t");
     if (stationParts.size() >= 13)
@@ -282,8 +274,7 @@ static bool GetAviationStationFromWmoFlatTableString(const std::string &theStati
 
       if (latlonOk && wmoOk)
       {
-        if (wmoId == missingWmoId)
-          wmoId = currentWmoIdCounter++;
+        if (wmoId == missingWmoId) wmoId = currentWmoIdCounter++;
         theStationOut.SetIdent(wmoId);
         theStationOut.SetLatitude(lat);
         theStationOut.SetLongitude(lon);

--- a/smarttools/NFmiAviationStationInfoSystem.h
+++ b/smarttools/NFmiAviationStationInfoSystem.h
@@ -9,8 +9,8 @@
 
 #include <newbase/NFmiStation.h>
 
-#include <string>
 #include <map>
+#include <string>
 
 class NFmiAviationStation : public NFmiStation
 {
@@ -29,6 +29,7 @@ class NFmiAviationStation : public NFmiStation
   const std::string &IcaoStr(void) const { return itsIcaoStr; }
   void IcaoStr(const std::string &newValue) { itsIcaoStr = newValue; }
   NFmiLocation *Clone(void) const { return new NFmiAviationStation(*this); }
+
  private:
   std::string itsIcaoStr;  // icao tunnus (esim. EFHK)
 };
@@ -51,6 +52,7 @@ class NFmiAviationStationInfoSystem
   NFmiAviationStation *FindStation(const std::string &theIcaoId);
   NFmiAviationStation *FindStation(long theWmoId);
   bool WmoStationsWanted(void) const { return fWmoStationsWanted; }
+
  private:
   std::string
       itsInitLogMessage;  // onnistuneen initialisoinnin viesti, missä voi olla varoituksia lokiin.
@@ -59,6 +61,5 @@ class NFmiAviationStationInfoSystem
   bool fWmoStationsWanted;  // tämä päättää, käytetäänkö luokassa WMO vai ICAO asemia
   bool fVerboseMode;
 };
-
 
 // ======================================================================

--- a/smarttools/NFmiCalculationConstantValue.cpp
+++ b/smarttools/NFmiCalculationConstantValue.cpp
@@ -7,8 +7,8 @@
 //**********************************************************
 
 #include "NFmiCalculationConstantValue.h"
-#include <newbase/NFmiDataModifier.h>
 #include <newbase/NFmiDataIterator.h>
+#include <newbase/NFmiDataModifier.h>
 #include <newbase/NFmiFastQueryInfo.h>
 
 // ****************************************************************************
@@ -18,12 +18,8 @@
 //--------------------------------------------------------
 // Constructor/Destructor
 //--------------------------------------------------------
-NFmiCalculationConstantValue::NFmiCalculationConstantValue(double value) : itsValue(value)
-{
-}
-NFmiCalculationConstantValue::~NFmiCalculationConstantValue()
-{
-}
+NFmiCalculationConstantValue::NFmiCalculationConstantValue(double value) : itsValue(value) {}
+NFmiCalculationConstantValue::~NFmiCalculationConstantValue() {}
 NFmiCalculationConstantValue::NFmiCalculationConstantValue(
     const NFmiCalculationConstantValue &theOther)
     : NFmiAreaMaskImpl(theOther), itsValue(theOther.itsValue)
@@ -85,9 +81,7 @@ NFmiCalculationRampFuction::NFmiCalculationRampFuction(
 {
 }
 
-NFmiCalculationRampFuction::~NFmiCalculationRampFuction(void)
-{
-}
+NFmiCalculationRampFuction::~NFmiCalculationRampFuction(void) {}
 NFmiCalculationRampFuction::NFmiCalculationRampFuction(const NFmiCalculationRampFuction &theOther)
     : NFmiInfoAreaMask(theOther)
 {
@@ -125,9 +119,7 @@ NFmiCalculationIntegrationFuction::NFmiCalculationIntegrationFuction(
 {
 }
 
-NFmiCalculationIntegrationFuction::~NFmiCalculationIntegrationFuction(void)
-{
-}
+NFmiCalculationIntegrationFuction::~NFmiCalculationIntegrationFuction(void) {}
 double NFmiCalculationIntegrationFuction::Value(const NFmiCalculationParams &theCalculationParams,
                                                 bool /* fUseTimeInterpolationAlways */)
 {
@@ -170,9 +162,7 @@ NFmiCalculationRampFuctionWithAreaMask::NFmiCalculationRampFuctionWithAreaMask(
 {
 }
 
-NFmiCalculationRampFuctionWithAreaMask::~NFmiCalculationRampFuctionWithAreaMask(void)
-{
-}
+NFmiCalculationRampFuctionWithAreaMask::~NFmiCalculationRampFuctionWithAreaMask(void) {}
 NFmiCalculationRampFuctionWithAreaMask::NFmiCalculationRampFuctionWithAreaMask(
     const NFmiCalculationRampFuctionWithAreaMask &theOther)
     : NFmiAreaMaskImpl(theOther),
@@ -194,9 +184,7 @@ NFmiAreaMask *NFmiCalculationRampFuctionWithAreaMask::Clone(void) const
 // ****************************************************************************
 double NFmiCalculationDeltaZValue::itsHeightValue;
 
-NFmiCalculationDeltaZValue::NFmiCalculationDeltaZValue(void) : NFmiAreaMaskImpl()
-{
-}
+NFmiCalculationDeltaZValue::NFmiCalculationDeltaZValue(void) : NFmiAreaMaskImpl() {}
 NFmiCalculationDeltaZValue::NFmiCalculationDeltaZValue(const NFmiCalculationDeltaZValue &theOther)
     : NFmiAreaMaskImpl(theOther)
 {
@@ -225,18 +213,13 @@ NFmiPeekTimeMask::NFmiPeekTimeMask(Type theMaskType,
   itsFunctionArgumentCount = theArgumentCount;
 }
 
-NFmiPeekTimeMask::~NFmiPeekTimeMask(void)
-{
-}
+NFmiPeekTimeMask::~NFmiPeekTimeMask(void) {}
 NFmiPeekTimeMask::NFmiPeekTimeMask(const NFmiPeekTimeMask &theOther)
     : NFmiInfoAreaMask(theOther), itsTimeOffsetInMinutes(theOther.itsTimeOffsetInMinutes)
 {
 }
 
-NFmiAreaMask *NFmiPeekTimeMask::Clone(void) const
-{
-  return new NFmiPeekTimeMask(*this);
-}
+NFmiAreaMask *NFmiPeekTimeMask::Clone(void) const { return new NFmiPeekTimeMask(*this); }
 double NFmiPeekTimeMask::Value(const NFmiCalculationParams &theCalculationParams,
                                bool /* fUseTimeInterpolationAlways */)
 {

--- a/smarttools/NFmiCalculationConstantValue.h
+++ b/smarttools/NFmiCalculationConstantValue.h
@@ -7,9 +7,9 @@
 //
 //**********************************************************
 
+#include <boost/shared_ptr.hpp>
 #include <newbase/NFmiAreaMaskImpl.h>
 #include <newbase/NFmiInfoAreaMask.h>
-#include <boost/shared_ptr.hpp>
 
 class NFmiDataModifier;
 class NFmiDataIterator;
@@ -28,6 +28,7 @@ class NFmiCalculationConstantValue : public NFmiAreaMaskImpl
 
   void SetValue(double value) { itsValue = value; }
   double GetValue(void) const { return itsValue; }
+
  private:
   double itsValue;
 };
@@ -53,6 +54,7 @@ class NFmiCalculationDeltaZValue : public NFmiAreaMaskImpl
   // tätä funktiota käyttämällä asetetaan korkeus 'siivun' paksuus. HUOM! se on staattinen kuten on
   // itsHeightValue-dataosakin, joten se tulee kaikille 'DeltaZ':oille yhteiseksi arvoksi.
   static void SetDeltaZValue(double value) { itsHeightValue = value; }
+
  private:
   static double itsHeightValue;
 };

--- a/smarttools/NFmiColor.h
+++ b/smarttools/NFmiColor.h
@@ -144,24 +144,13 @@ inline void NFmiColor::SetRGBA(const FmiRGBColor &aColor)
   itsColor.alpha = (aColor.alpha >= 0.0f) ? ((aColor.alpha <= 1.0f) ? aColor.alpha : 1.0f) : 0.0f;
 }
 
-inline NFmiColor::NFmiColor(const NFmiColor &aColor) : itsColor(aColor.itsColor)
-{
-}
+inline NFmiColor::NFmiColor(const NFmiColor &aColor) : itsColor(aColor.itsColor) {}
 
-inline NFmiColor::NFmiColor(const FmiRGBColor &aColor) : itsColor()
-{
-  SetRGBA(aColor);
-}
+inline NFmiColor::NFmiColor(const FmiRGBColor &aColor) : itsColor() { SetRGBA(aColor); }
 
-inline std::ostream &operator<<(std::ostream &os, const NFmiColor &ob)
-{
-  return ob.Write(os);
-}
+inline std::ostream &operator<<(std::ostream &os, const NFmiColor &ob) { return ob.Write(os); }
 
-inline std::istream &operator>>(std::istream &os, NFmiColor &ob)
-{
-  return ob.Read(os);
-}
+inline std::istream &operator>>(std::istream &os, NFmiColor &ob) { return ob.Read(os); }
 
 inline void NFmiColor::SetRGBA(float aRedValue,
                                float aGreenValue,
@@ -238,6 +227,5 @@ inline void NFmiColor::Mix(const NFmiColor &anOtherColor, float mixingRatio)
       (1.F - mixingRatio) * static_cast<float>(itsColor.green) + mixingRatio * anOtherColor.Green(),
       (1.F - mixingRatio) * static_cast<float>(itsColor.blue) + mixingRatio * anOtherColor.Blue());
 }
-
 
 // ======================================================================

--- a/smarttools/NFmiColorSpaces.cpp
+++ b/smarttools/NFmiColorSpaces.cpp
@@ -5,13 +5,9 @@
 #include "NFmiColorSpaces.h"
 
 // NFmiColorSpaces::RGB_color -struct
-NFmiColorSpaces::RGB_color::RGB_color(void) : r(0), g(0), b(0)
-{
-}
+NFmiColorSpaces::RGB_color::RGB_color(void) : r(0), g(0), b(0) {}
 
-NFmiColorSpaces::RGB_color::RGB_color(int r_, int g_, int b_) : r(r_), g(g_), b(b_)
-{
-}
+NFmiColorSpaces::RGB_color::RGB_color(int r_, int g_, int b_) : r(r_), g(g_), b(b_) {}
 
 NFmiColorSpaces::RGB_color::RGB_color(const NFmiColor &theColor)
     : r(static_cast<int>(FmiRound(theColor.GetRed() * 255.f))),
@@ -21,13 +17,9 @@ NFmiColorSpaces::RGB_color::RGB_color(const NFmiColor &theColor)
 }
 
 // NFmiColorSpaces::HSL_color -struct
-NFmiColorSpaces::HSL_color::HSL_color(void) : h(0), s(0), l(0)
-{
-}
+NFmiColorSpaces::HSL_color::HSL_color(void) : h(0), s(0), l(0) {}
 
-NFmiColorSpaces::HSL_color::HSL_color(int h_, int s_, int l_) : h(h_), s(s_), l(l_)
-{
-}
+NFmiColorSpaces::HSL_color::HSL_color(int h_, int s_, int l_) : h(h_), s(s_), l(l_) {}
 
 // Color conversio funktioita:
 // <summary>
@@ -120,10 +112,8 @@ NFmiColorSpaces::RGB_color NFmiColorSpaces::HSLtoRGB(double h, double s, double 
 
     for (int i = 0; i < 3; i++)
     {
-      if (T[i] < 0)
-        T[i] += 1.0;
-      if (T[i] > 1)
-        T[i] -= 1.0;
+      if (T[i] < 0) T[i] += 1.0;
+      if (T[i] > 1) T[i] -= 1.0;
 
       if ((T[i] * 6) < 1)
       {
@@ -160,10 +150,8 @@ NFmiColor NFmiColorSpaces::GetBrighterColor(const NFmiColor &theColor, double th
   else  // jos lightness oli 0, pitää vain lisätä kirkastus kerroin
     lightness = theBrightningFactor;
 
-  if (lightness > 100)
-    lightness = 100;
-  if (lightness < 0)
-    lightness = 0;
+  if (lightness > 100) lightness = 100;
+  if (lightness < 0) lightness = 0;
 
   RGB_color rgbCol2 = NFmiColorSpaces::HSLtoRGB(hslCol.h, hslCol.s / 100., lightness / 100.);
 

--- a/smarttools/NFmiColorSpaces.h
+++ b/smarttools/NFmiColorSpaces.h
@@ -54,4 +54,3 @@ RGB_color HSLtoRGB(double h, double s, double l);
 // jos prosentti luku on > 0, vaalenee väri, jos se on < 0, tummenee väri.
 NFmiColor GetBrighterColor(const NFmiColor &theColor, double theBrightningFactor);
 }
-

--- a/smarttools/NFmiDataStoringHelpers.cpp
+++ b/smarttools/NFmiDataStoringHelpers.cpp
@@ -29,8 +29,7 @@ void NFmiDataStoringHelpers::WriteTimeWithOffsets(const NFmiMetTime &theUsedCurr
   aTime.SetSec(0);
   long hourShift = aTime.DifferenceInHours(theTime);
   long usedDayShift = hourShift / 24;
-  if (hourShift > 0)
-    usedDayShift++;
+  if (hourShift > 0) usedDayShift++;
   os << utcHour << " " << utcMinute << " " << usedDayShift << std::endl;
 }
 
@@ -56,8 +55,7 @@ void NFmiDataStoringHelpers::ReadTimeWithOffsets(const NFmiMetTime &theUsedCurre
   // Siksi jos utc-tunti oli 0 ja dayShift oli positiivinen, pitää lopullista aikaa siirtää päivällä
   // eteenpäin
   bool uglyAfterFix = ((utcHour == 0) && (dayShift > 0));
-  if (uglyAfterFix)
-    aTime.ChangeByDays(1);
+  if (uglyAfterFix) aTime.ChangeByDays(1);
   theTime = aTime;
 }
 
@@ -152,8 +150,7 @@ void NFmiDataStoringHelpers::NFmiExtraDataStorage::Write(std::ostream &os) const
       os << " ";
     os << itsDoubleValues[i];
   }
-  if (ssize > 0)
-    os << std::endl;
+  if (ssize > 0) os << std::endl;
 
   ssize = itsStringValues.size();
   os << ssize << std::endl;
@@ -164,8 +161,7 @@ void NFmiDataStoringHelpers::NFmiExtraDataStorage::Write(std::ostream &os) const
     NFmiString tmpStr(itsStringValues[i]);
     os << tmpStr;  // NFmiString heittää itse endl:in perään.
   }
-  if (ssize > 0)
-    os << std::endl;
+  if (ssize > 0) os << std::endl;
 }
 
 void NFmiDataStoringHelpers::NFmiExtraDataStorage::Read(std::istream &is)

--- a/smarttools/NFmiDataStoringHelpers.h
+++ b/smarttools/NFmiDataStoringHelpers.h
@@ -10,8 +10,8 @@
 #include <newbase/NFmiStringTools.h>
 #include <newbase/NFmiTimeBag.h>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace NFmiDataStoringHelpers
 {
@@ -30,8 +30,7 @@ inline void WriteContainer(const T &theContainer,
   // MSVC 2008 ei sitten osannut enää kääntää alempana olevaa koodia (KUN annetussa containerissa
   // oli luokan sisäisiä luokkia), joten tein for loopin, joka meni läpi.
   size_t storedCount = theReallyStoredSize;
-  if (storedCount > theContainer.size())
-    storedCount = theContainer.size();
+  if (storedCount > theContainer.size()) storedCount = theContainer.size();
 
   os << storedCount << std::endl;
   for (size_t i = 0; i < storedCount; i++)
@@ -135,4 +134,3 @@ inline std::istream &operator>>(std::istream &is,
   item.Read(is);
   return is;
 }
-

--- a/smarttools/NFmiDictionaryFunction.h
+++ b/smarttools/NFmiDictionaryFunction.h
@@ -11,4 +11,3 @@
 // HUOM! Tämä on kopio NFmiEditMapGeneralDataDoc-luokan metodista, kun en voinut antaa tänne
 // dokumenttia
 std::string GetDictionaryString(const char *theMagicWord);
-

--- a/smarttools/NFmiDrawParam.cpp
+++ b/smarttools/NFmiDrawParam.cpp
@@ -31,8 +31,8 @@
 //
 //**********************************************************
 #include "NFmiDrawParam.h"
-#include "NFmiDataStoringHelpers.h"
 #include "NFmiColorSpaces.h"
+#include "NFmiDataStoringHelpers.h"
 
 #include <fstream>
 
@@ -520,9 +520,7 @@ NFmiDrawParam::NFmiDrawParam(const NFmiDrawParam& other)
 //-------------------------------------------------------
 // ~NFmiDrawParam
 //-------------------------------------------------------
-NFmiDrawParam::~NFmiDrawParam(void)
-{
-}
+NFmiDrawParam::~NFmiDrawParam(void) {}
 
 //-------------------------------------------------------
 // Init
@@ -1064,8 +1062,7 @@ std::ostream& NFmiDrawParam::Write(std::ostream& file) const
     file << "possible_extra_data" << std::endl;
     file << extraData;
 
-    if (file.fail())
-      throw std::runtime_error("NFmiDrawParam::Write failed");
+    if (file.fail()) throw std::runtime_error("NFmiDrawParam::Write failed");
     //***********************************************
     //********** 'versio 3' parametreja *************
     //***********************************************
@@ -1097,8 +1094,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
   char temp[80];
   std::string tmpStr;
   int number;
-  if (!file)
-    return file;
+  if (!file) return file;
   file >> temp;
   if (std::string(temp) == std::string("Version"))
   {
@@ -1110,8 +1106,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
 
     if (itsInitFileVersionNumber >= 1.)  // tämä on vain esimerkki siitä mitä joskus tulee olemaan
     {
-      if (!file)
-        return file;
+      if (!file) return file;
       file >> temp;                // luetaan nimike pois
       std::getline(file, tmpStr);  // luetaan ed. rivinvaihto pois jaloista
       std::getline(file, tmpStr);  // luetaan rivin loppuun, jos lyhenteessä spaceja mahdollisesti
@@ -1167,8 +1162,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
       file >> temp;  // luetaan nimike pois
       file >> itsAbsoluteMaxValue;
 
-      if (!file)
-        return file;
+      if (!file) return file;
 
       file >> temp;  // luetaan nimike pois
       file >> itsTimeSeriesScaleMin;
@@ -1187,16 +1181,14 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
       file >> temp;  // luetaan nimike pois
       file >> itsPossibleViewTypeCount;
       file >> temp;  // luetaan nimike pois
-      if (!file)
-        return file;
+      if (!file) return file;
       for (int ind = 0; ind < itsPossibleViewTypeCount; ind++)
       {
         file >> number;
         itsPossibleViewTypeList[ind] = NFmiMetEditorTypes::View(number);
       }
 
-      if (!file)
-        return file;
+      if (!file) return file;
 
       file >> temp;  // luetaan nimike pois
       file >> itsTimeSerialModifyingLimit;
@@ -1213,8 +1205,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
       // on pienempi kuin 1, annetaan arvoksi 1.
       file >> number;
       number -= 100;
-      if (number < 1)
-        number = 1;
+      if (number < 1) number = 1;
       itsStationDataViewType = NFmiMetEditorTypes::View(number);
       file >> temp;  // luetaan nimike pois
       bool tmpBool = false;
@@ -1222,8 +1213,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
 
       file >> temp;  // luetaan nimike pois
       file >> temp;
-      if (!file)
-        return file;
+      if (!file) return file;
       itsUnit = std::string(temp);
 
       file >> temp;  // luetaan nimike pois
@@ -1242,8 +1232,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
       //***********************************************
       if (itsInitFileVersionNumber >= 2.)  // tämä on vain esimerkki siitä mitä joskus tulee olemaan
       {
-        if (!file)
-          return file;
+        if (!file) return file;
         file >> itsStationSymbolColorShadeLowValue;
         file >> itsStationSymbolColorShadeMidValue;
         file >> itsStationSymbolColorShadeHighValue;
@@ -1276,8 +1265,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
         file >> itsSimpleIsoLineColorShadeHighValueColor;
         file >> itsSimpleIsoLineColorShadeClassCount;
 
-        if (!file)
-          return file;
+        if (!file) return file;
         int i = 0;
         int size;
         file >> size;
@@ -1315,21 +1303,18 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
           itsSpecialIsoLineShowLabelBox[i] = foobar;
         }
 
-        if (!file)
-          return file;
+        if (!file) return file;
         file >> fDrawOnlyOverMask;
         file >> fUseCustomColorContouring;
 
         file >> size;
-        if (!file)
-          return file;
+        if (!file) return file;
         itsSpecialColorContouringValues.resize(size);
         for (i = 0; i < size; i++)
           file >> itsSpecialColorContouringValues[i];
 
         file >> size;
-        if (!file)
-          return file;
+        if (!file) return file;
         itsSpecialColorContouringColorIndexies.resize(size);
         for (i = 0; i < size; i++)
           file >> itsSpecialColorContouringColorIndexies[i];
@@ -1356,8 +1341,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
         file >> itsIsoLineHatchColor2;
         file >> itsColorContouringColorShadeHigh2ValueColor;
         file >> itsIsoLineLabelDigitCount;
-        if (!file)
-          return file;
+        if (!file) return file;
         //***********************************************
         //********** 'versio 2' parametreja *************
         //***********************************************
@@ -1387,8 +1371,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
 
         file >> fUseCustomIsoLineing >> itsContourLabelDigitCount;
 
-        if (file.fail())
-          throw std::runtime_error("NFmiDrawParam::Write failed");
+        if (file.fail()) throw std::runtime_error("NFmiDrawParam::Write failed");
 
         file >> temp;  // luetaan 'possible_extra_data' pois
         NFmiDataStoringHelpers::NFmiExtraDataStorage
@@ -1433,8 +1416,7 @@ std::istream& NFmiDrawParam::Read(std::istream& file)
               extraData
                   .itsStringValues[0]));  // laitetaan asetus-funktion läpi, jossa raja tarkistukset
 
-        if (file.fail())
-          throw std::runtime_error("NFmiDrawParam::Write failed");
+        if (file.fail()) throw std::runtime_error("NFmiDrawParam::Write failed");
         //***********************************************
         //********** 'versio 3' parametreja *************
         //***********************************************
@@ -1493,10 +1475,8 @@ bool NFmiDrawParam::UseArchiveModelData(void) const
 {
   if (IsModelRunDataType())
   {
-    if (itsModelOriginTime != NFmiMetTime::gMissingTime)
-      return true;
-    if (itsModelRunIndex < 0)
-      return true;
+    if (itsModelOriginTime != NFmiMetTime::gMissingTime) return true;
+    if (itsModelRunIndex < 0) return true;
   }
   return false;
 }
@@ -1512,8 +1492,7 @@ bool NFmiDrawParam::IsModelRunDataType(NFmiInfoData::Type theDataType)
       theDataType == NFmiInfoData::kModelHelpData || theDataType == NFmiInfoData::kKepaData ||
       theDataType == NFmiInfoData::kTrajectoryHistoryData)
     return true;
-  if (theDataType == NFmiInfoData::kClimatologyData)
-    return true;
+  if (theDataType == NFmiInfoData::kClimatologyData) return true;
   return false;
 }
 
@@ -1521,8 +1500,7 @@ bool NFmiDrawParam::DoDataComparison(void)
 {
   if (itsDataComparisonProdId != 0)
   {
-    if (itsDataComparisonType != NFmiInfoData::kNoDataType)
-      return true;
+    if (itsDataComparisonType != NFmiInfoData::kNoDataType) return true;
   }
   return false;
 }
@@ -1541,8 +1519,7 @@ bool NFmiDrawParam::IsMacroParamCase(bool justCheckDataType)
 {
   if (justCheckDataType)
   {
-    if (IsMacroParamCase(itsDataType))
-      return true;
+    if (IsMacroParamCase(itsDataType)) return true;
   }
   else
   {

--- a/smarttools/NFmiDrawParam.h
+++ b/smarttools/NFmiDrawParam.h
@@ -33,14 +33,14 @@
 #include "NFmiColor.h"
 #include "NFmiMetEditorTypes.h"
 
-#include <newbase/NFmiParameterName.h>
-#include <newbase/NFmiDataIdent.h>
-#include <newbase/NFmiPoint.h>
-#include <newbase/NFmiLevel.h>
-#include <newbase/NFmiInfoData.h>
-#include <newbase/NFmiDataMatrix.h>  // täältä tulee myös checkedVector
-#include <newbase/NFmiMetTime.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiDataIdent.h>
+#include <newbase/NFmiDataMatrix.h>  // täältä tulee myös checkedVector
+#include <newbase/NFmiInfoData.h>
+#include <newbase/NFmiLevel.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiParameterName.h>
+#include <newbase/NFmiPoint.h>
 
 class NFmiDrawingEnvironment;
 
@@ -80,8 +80,7 @@ class NFmiDrawParam
   void TimeSerialModelRunCount(int newValue)
   {
     itsTimeSerialModelRunCount = newValue;
-    if (itsTimeSerialModelRunCount < 0)
-      itsTimeSerialModelRunCount = 0;
+    if (itsTimeSerialModelRunCount < 0) itsTimeSerialModelRunCount = 0;
   }
   int ModelRunDifferenceIndex(void) const { return itsModelRunDifferenceIndex; }
   void ModelRunDifferenceIndex(int newValue) { itsModelRunDifferenceIndex = newValue; }
@@ -162,15 +161,13 @@ class NFmiDrawParam
   void IsoLineGab(const double theIsoLineGab)
   {
     itsIsoLineGab = theIsoLineGab;
-    if (itsIsoLineGab == 0)
-      itsIsoLineGab = 1;  // gappi ei voi olla 0
+    if (itsIsoLineGab == 0) itsIsoLineGab = 1;  // gappi ei voi olla 0
   }
   double IsoLineGab(void) const { return itsIsoLineGab; };
   void ContourGab(const double theContourGab)
   {
     itsContourGab = theContourGab;
-    if (itsContourGab == 0)
-      itsContourGab = 1;
+    if (itsContourGab == 0) itsContourGab = 1;
   }
   double ContourGab(void) const { return itsContourGab; };
   void ModifyingStep(const double theModifyingStep) { itsModifyingStep = theModifyingStep; };
@@ -668,19 +665,16 @@ class NFmiDrawParam
   void IsoLineLabelDigitCount(int newValue)
   {
     itsIsoLineLabelDigitCount = newValue;
-    if (itsIsoLineLabelDigitCount > 10)
-      itsIsoLineLabelDigitCount = 10;
+    if (itsIsoLineLabelDigitCount > 10) itsIsoLineLabelDigitCount = 10;
     itsContourLabelDigitCount = newValue;
-    if (itsContourLabelDigitCount > 10)
-      itsContourLabelDigitCount = 10;
+    if (itsContourLabelDigitCount > 10) itsContourLabelDigitCount = 10;
   }
 
   int ContourLabelDigitCount(void) const { return itsContourLabelDigitCount; }
   void ContourLabelDigitCount(int newValue)
   {
     itsContourLabelDigitCount = newValue;
-    if (itsContourLabelDigitCount > 10)
-      itsContourLabelDigitCount = 10;
+    if (itsContourLabelDigitCount > 10) itsContourLabelDigitCount = 10;
   }
 
   //**************************************************************
@@ -690,10 +684,8 @@ class NFmiDrawParam
   void Alpha(float newValue)
   {
     itsAlpha = newValue;
-    if (itsAlpha < NFmiDrawParam::itsMinAlpha)
-      itsAlpha = NFmiDrawParam::itsMinAlpha;
-    if (itsAlpha > 100.f)
-      itsAlpha = 100.f;
+    if (itsAlpha < NFmiDrawParam::itsMinAlpha) itsAlpha = NFmiDrawParam::itsMinAlpha;
+    if (itsAlpha > 100.f) itsAlpha = 100.f;
   }
 
   bool ViewMacroDrawParam(void) const { return fViewMacroDrawParam; }
@@ -952,9 +944,5 @@ inline std::ostream& operator<<(std::ostream& os, const NFmiDrawParam& item)
 {
   return item.Write(os);
 }
-inline std::istream& operator>>(std::istream& is, NFmiDrawParam& item)
-{
-  return item.Read(is);
-}
+inline std::istream& operator>>(std::istream& is, NFmiDrawParam& item) { return item.Read(is); }
 //@}
-

--- a/smarttools/NFmiDrawParamFactory.cpp
+++ b/smarttools/NFmiDrawParamFactory.cpp
@@ -31,8 +31,8 @@
 #include "NFmiDrawParamFactory.h"
 #include "NFmiDrawParam.h"
 
-#include <newbase/NFmiValueString.h>
 #include <newbase/NFmiFileSystem.h>
+#include <newbase/NFmiValueString.h>
 
 #include <cassert>
 
@@ -78,9 +78,7 @@ NFmiDrawParamFactory::NFmiDrawParamFactory(bool createDrawParamFileIfNotExist,
 //--------------------------------------------------------
 // ~FmiDrawParamFactory(void)
 //--------------------------------------------------------
-NFmiDrawParamFactory::~NFmiDrawParamFactory(void)
-{
-}
+NFmiDrawParamFactory::~NFmiDrawParamFactory(void) {}
 
 //--------------------------------------------------------
 // DrawParam
@@ -119,8 +117,7 @@ boost::shared_ptr<NFmiDrawParam> NFmiDrawParamFactory::CreateEmptyInfoDrawParam(
     const NFmiDataIdent& theIdent)
 {
   boost::shared_ptr<NFmiDrawParam> drawParam(new NFmiDrawParam());
-  if (drawParam)
-    drawParam->Param(theIdent);
+  if (drawParam) drawParam->Param(theIdent);
   return CreateDrawParam(drawParam, false);
 }
 
@@ -157,10 +154,7 @@ boost::shared_ptr<NFmiDrawParam> NFmiDrawParamFactory::CreateDrawParam(
 //--------------------------------------------------------
 // Init
 //--------------------------------------------------------
-bool NFmiDrawParamFactory::Init()
-{
-  return true;
-}
+bool NFmiDrawParamFactory::Init() { return true; }
 
 //--------------------------------------------------------
 // CreateFileName, private

--- a/smarttools/NFmiDrawParamFactory.h
+++ b/smarttools/NFmiDrawParamFactory.h
@@ -44,6 +44,7 @@ class NFmiDrawParamFactory
   bool Init();
   const std::string& LoadDirectory(void) const { return itsLoadDirectory; };
   void LoadDirectory(const std::string& newValue) { itsLoadDirectory = newValue; };
+
  private:
   boost::shared_ptr<NFmiDrawParam> CreateDrawParam(boost::shared_ptr<NFmiDrawParam>& theDrawParam,
                                                    bool fDoCrossSection);
@@ -54,4 +55,3 @@ class NFmiDrawParamFactory
                                         // mutta SmarToolFiltterin ei tarvitse.
   bool fOnePressureLevelDrawParam;
 };
-

--- a/smarttools/NFmiDrawParamList.cpp
+++ b/smarttools/NFmiDrawParamList.cpp
@@ -47,10 +47,7 @@ NFmiDrawParamList::NFmiDrawParamList(void)
 //--------------------------------------------------------
 // Destructor  ~NFmiDrawParamList
 //--------------------------------------------------------
-NFmiDrawParamList::~NFmiDrawParamList(void)
-{
-  Clear();
-}
+NFmiDrawParamList::~NFmiDrawParamList(void) { Clear(); }
 
 //--------------------------------------------------------
 // Add
@@ -120,8 +117,7 @@ void NFmiDrawParamList::ClearBorrowedParams(void)
 {
   for (Reset(); Next();)
   {
-    if (Current()->BorrowedParam())
-      Remove();
+    if (Current()->BorrowedParam()) Remove();
   }
   HasBorrowedParams(false);
 }
@@ -150,8 +146,7 @@ bool NFmiDrawParamList::Reset(void)
 //--------------------------------------------------------
 bool NFmiDrawParamList::Next(void)
 {
-  if (itsIter == itsList.end())
-    return false;
+  if (itsIter == itsList.end()) return false;
   if (fBeforeFirstItem)
   {
     fBeforeFirstItem = false;
@@ -228,9 +223,7 @@ bool NFmiDrawParamList::Find(NFmiDrawParam* item)
 //--------------------------------------------------------
 // Update
 //--------------------------------------------------------
-void NFmiDrawParamList::Update(void)
-{
-}
+void NFmiDrawParamList::Update(void) {}
 
 void NFmiDrawParamList::HideAllParams(bool newState)
 {
@@ -263,8 +256,7 @@ bool NFmiDrawParamList::Find(const NFmiDataIdent& theParam,
     if (theParam.GetParamIdent() ==
         NFmiInfoData::kFmiSpSynoPlot)  // pirun synop-parametrille pitää taas tehdä virityksiä
     {
-      if (fUseOnlyParamId || drawParam->Param() == theParam)
-        return true;
+      if (fUseOnlyParamId || drawParam->Param() == theParam) return true;
     }
     else
     {
@@ -273,15 +265,12 @@ bool NFmiDrawParamList::Find(const NFmiDataIdent& theParam,
       {
         if (theDataType == NFmiInfoData::kAnyData || drawParam->DataType() == theDataType)
         {
-          if (fIgnoreLevelInfo)
-            return true;
-          if (theLevel == 0 && drawParam->Level().LevelType() == 0)
-            return true;
+          if (fIgnoreLevelInfo) return true;
+          if (theLevel == 0 && drawParam->Level().LevelType() == 0) return true;
           if (drawParam->Level().LevelType() == 0 && (theLevel->LevelType() == kFmiAnyLevelType ||
                                                       theLevel->LevelType() == kFmiMeanSeaLevel))
             return true;  // tämä case tulee kun nykyään tehdään pinta parametreja
-          if (theLevel && (*(theLevel) == drawParam->Level()))
-            return true;
+          if (theLevel && (*(theLevel) == drawParam->Level())) return true;
         }
       }
     }
@@ -511,8 +500,7 @@ int NFmiDrawParamList::FindActive(void)
   int index = 1;
   for (Reset(); Next(); index++)
   {
-    if (Current()->IsActive())
-      return index;
+    if (Current()->IsActive()) return index;
   }
   return 0;
 }
@@ -522,8 +510,7 @@ int NFmiDrawParamList::FindEdited(void)
   int index = 1;
   for (Reset(); Next(); index++)
   {
-    if (Current()->IsParamEdited())
-      return index;
+    if (Current()->IsParamEdited()) return index;
   }
   return 0;
 }
@@ -534,8 +521,7 @@ int NFmiDrawParamList::FindEdited(void)
 */
 void NFmiDrawParamList::CopyList(NFmiDrawParamList& theList, bool clearFirst)
 {
-  if (clearFirst)
-    Clear();
+  if (clearFirst) Clear();
 
   for (theList.Reset(); theList.Next();)
   {
@@ -550,12 +536,10 @@ void NFmiDrawParamList::CopyList(NFmiDrawParamList& theList, bool clearFirst)
 // Jos listassa ei ole yhtään aktiivista, ensimmäinen aktivoidaan.
 void NFmiDrawParamList::ActivateOnlyOne(void)
 {
-  if (NumberOfItems() == 0)
-    return;
+  if (NumberOfItems() == 0) return;
   int activeIndex = FindActive();
   DeactivateAll();
-  if (activeIndex == 0)
-    activeIndex++;
+  if (activeIndex == 0) activeIndex++;
   if (Index(activeIndex))  // pitäisi löytyä!!
     Current()->Activate(true);
 }

--- a/smarttools/NFmiDrawParamList.h
+++ b/smarttools/NFmiDrawParamList.h
@@ -31,11 +31,11 @@
 //**********************************************************
 #pragma once
 
+#include "NFmiDrawParam.h"
 #include "NFmiSortedPtrList.h"
+#include <boost/shared_ptr.hpp>
 #include <newbase/NFmiDataMatrix.h>
 #include <newbase/NFmiInfoData.h>
-#include "NFmiDrawParam.h"
-#include <boost/shared_ptr.hpp>
 #include <list>
 
 #ifdef _MSC_VER
@@ -113,4 +113,3 @@ class NFmiDrawParamList
   bool fDirtyList;
   bool fHasBorrowedParams;  // onko tällä listalla 'lainattuja' parametreja
 };
-

--- a/smarttools/NFmiExtraMacroParamData.cpp
+++ b/smarttools/NFmiExtraMacroParamData.cpp
@@ -1,6 +1,6 @@
 #include "NFmiExtraMacroParamData.h"
-#include <newbase/NFmiFastQueryInfo.h>
 #include "NFmiInfoOrganizer.h"
+#include <newbase/NFmiFastQueryInfo.h>
 
 #include <boost/math/special_functions/round.hpp>
 

--- a/smarttools/NFmiExtraMacroParamData.h
+++ b/smarttools/NFmiExtraMacroParamData.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <newbase/NFmiProducer.h>
-#include <newbase/NFmiLevelType.h>
 #include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiLevelType.h>
+#include <newbase/NFmiProducer.h>
 
 #include <boost/shared_ptr.hpp>
 
@@ -51,6 +51,7 @@ class NFmiExtraMacroParamData
   void ObservationRadiusInKm(float newValue) { itsObservationRadiusInKm = newValue; }
   float ObservationRadiusRelative() const { return itsObservationRadiusRelative; }
   void ObservationRadiusRelative(float newValue) { itsObservationRadiusRelative = newValue; }
+
  private:
   void InitializeResolutionWithEditedData(NFmiInfoOrganizer &theInfoOrganizer);
   void InitializeResolutionData(NFmiInfoOrganizer &theInfoOrganizer, float usedResolutionInKm);

--- a/smarttools/NFmiGridPointCache.h
+++ b/smarttools/NFmiGridPointCache.h
@@ -41,4 +41,3 @@ class NFmiGridPointCache
  private:
   pointMap itsPointCache;
 };
-

--- a/smarttools/NFmiGriddingHelperInterface.h
+++ b/smarttools/NFmiGriddingHelperInterface.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <newbase/NFmiDataMatrix.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiDataMatrix.h>
 
 class NFmiFastQueryInfo;
 class NFmiDrawParam;

--- a/smarttools/NFmiHarmonizerBookKeepingData.cpp
+++ b/smarttools/NFmiHarmonizerBookKeepingData.cpp
@@ -16,9 +16,7 @@ NFmiHarmonizerBookKeepingData::NFmiHarmonizerBookKeepingData(
 {
 }
 
-NFmiHarmonizerBookKeepingData::~NFmiHarmonizerBookKeepingData(void)
-{
-}
+NFmiHarmonizerBookKeepingData::~NFmiHarmonizerBookKeepingData(void) {}
 
 void NFmiHarmonizerBookKeepingData::InsertTime(const NFmiMetTime &theTime)
 {

--- a/smarttools/NFmiHarmonizerBookKeepingData.h
+++ b/smarttools/NFmiHarmonizerBookKeepingData.h
@@ -21,6 +21,7 @@ class NFmiHarmonizerBookKeepingData
   bool HarmonizeAllTimes(void) const { return fHarmonizeAllTimes; }
   void HarmonizeAllTimes(bool newValue) { fHarmonizeAllTimes = newValue; }
   std::set<NFmiMetTime> &HarmonizerTimesSet(void) { return itsHarmonizerTimesSet; }
+
  private:
   std::set<NFmiMetTime>
       itsHarmonizerTimesSet;  // tänne laitetaan kaikki muokatut ajat jotta voidaan
@@ -30,4 +31,3 @@ class NFmiHarmonizerBookKeepingData
   NFmiParamBag
       itsHarmonizerParams;  // tähän merkitään parametrit, joita on muokattu eri työkaluilla.
 };
-

--- a/smarttools/NFmiHelpDataInfo.cpp
+++ b/smarttools/NFmiHelpDataInfo.cpp
@@ -8,12 +8,12 @@
 #endif
 
 #include "NFmiHelpDataInfo.h"
-#include <newbase/NFmiProducerName.h>
 #include <newbase/NFmiArea.h>
 #include <newbase/NFmiAreaFactory.h>
-#include <newbase/NFmiStereographicArea.h>
-#include <newbase/NFmiSettings.h>
 #include <newbase/NFmiFileString.h>
+#include <newbase/NFmiProducerName.h>
+#include <newbase/NFmiSettings.h>
+#include <newbase/NFmiStereographicArea.h>
 
 using namespace std;
 
@@ -100,8 +100,7 @@ NFmiHelpDataInfo &NFmiHelpDataInfo::operator=(const NFmiHelpDataInfo &theOther)
     itsFakeProducerId = theOther.itsFakeProducerId;
     itsImageProjectionString = theOther.itsImageProjectionString;
     itsImageDataIdent = theOther.itsImageDataIdent;
-    if (theOther.itsImageArea)
-      itsImageArea.reset(theOther.itsImageArea->Clone());
+    if (theOther.itsImageArea) itsImageArea.reset(theOther.itsImageArea->Clone());
     fNotifyOnLoad = theOther.fNotifyOnLoad;
     itsNotificationLabel = theOther.itsNotificationLabel;
     itsCustomMenuFolder = theOther.itsCustomMenuFolder;
@@ -158,8 +157,7 @@ static void FixPathEndWithSeparator(std::string &theFixedPathStr)
     theFixedPathStr = static_cast<char *>(tmpFileStr);
 
     std::string::value_type lastLetter = theFixedPathStr[theFixedPathStr.size() - 1];
-    if (lastLetter != kFmiDirectorySeparator)
-      theFixedPathStr.push_back(kFmiDirectorySeparator);
+    if (lastLetter != kFmiDirectorySeparator) theFixedPathStr.push_back(kFmiDirectorySeparator);
   }
 }
 
@@ -185,10 +183,8 @@ static void MakeCombinedDataFilePattern(NFmiHelpDataInfo &theDataInfo,
     size_t i = lastDirFilePattern.size() - 1;
     for (; i > 0; i--)
     {
-      if (lastDirFilePattern[i] == '\\')
-        slashesFound++;
-      if (slashesFound > 1)
-        break;
+      if (lastDirFilePattern[i] == '\\') slashesFound++;
+      if (slashesFound > 1) break;
     }
 
     if (slashesFound > 1)
@@ -240,8 +236,7 @@ void NFmiHelpDataInfo::InitFromSettings(const std::string &theBaseKey,
     itsModelRunTimeGapInHours =
         NFmiSettings::Optional<float>(itsBaseNameSpace + "::ModelRunTimeGapInHours", 0);
 
-    if (IsCombineData())
-      ::MakeCombinedDataFilePattern(*this, theHelpDataSystem);
+    if (IsCombineData()) ::MakeCombinedDataFilePattern(*this, theHelpDataSystem);
 
     std::string imageProjectionKey(itsBaseNameSpace + "::ImageProjection");
     if (NFmiSettings::IsSet(imageProjectionKey))
@@ -263,10 +258,7 @@ void NFmiHelpDataInfo::InitFromSettings(const std::string &theBaseKey,
   }
 }
 
-void NFmiHelpDataInfo::ImageArea(boost::shared_ptr<NFmiArea> &newValue)
-{
-  itsImageArea = newValue;
-}
+void NFmiHelpDataInfo::ImageArea(boost::shared_ptr<NFmiArea> &newValue) { itsImageArea = newValue; }
 
 static std::string MakeCacheFilePattern(const NFmiHelpDataInfo &theDataInfo,
                                         const NFmiHelpDataInfoSystem &theHelpDataSystem)
@@ -348,10 +340,8 @@ NFmiDataIdent NFmiHelpDataInfoSystem::GetNextSatelChannel(const NFmiDataIdent &t
       currentIndex++;
     else
       currentIndex--;
-    if (currentIndex < 0)
-      currentIndex = counter - 1;
-    if (currentIndex >= counter)
-      currentIndex = 0;
+    if (currentIndex < 0) currentIndex = counter - 1;
+    if (currentIndex >= counter) currentIndex = 0;
     returnDataIdent = dataIdentVec[currentIndex];
   }
   return returnDataIdent;
@@ -386,8 +376,7 @@ void NFmiHelpDataInfoSystem::InitDataType(const std::string &theBaseKey,
     // eri datojen enable-ominaisuudesta yhteen konffitiedostoon (mm.
     // helpdatainfo_enable_data_fmi_heavy.conf),
     // tuli mahdolliseksi, että tässä tuli ns. haamu dataInfoja, jotka nyt pitää karsia.
-    if (hdi.DataType() != NFmiInfoData::kNoDataType)
-      theHelpDataInfos.push_back(hdi);
+    if (hdi.DataType() != NFmiInfoData::kNoDataType) theHelpDataInfos.push_back(hdi);
   }
 }
 
@@ -526,8 +515,7 @@ static NFmiHelpDataInfo *FindHelpDataInfo(checkedVector<NFmiHelpDataInfo> &theHe
 // Käy ensin läpi dynaamiset helpDataInfot ja sitten staattiset.
 NFmiHelpDataInfo *NFmiHelpDataInfoSystem::FindHelpDataInfo(const std::string &theFileNameFilter)
 {
-  if (theFileNameFilter.empty())
-    return 0;
+  if (theFileNameFilter.empty()) return 0;
 
   NFmiHelpDataInfo *helpInfo =
       ::FindHelpDataInfo(itsDynamicHelpDataInfos, theFileNameFilter, *this);

--- a/smarttools/NFmiHelpDataInfo.h
+++ b/smarttools/NFmiHelpDataInfo.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include <newbase/NFmiInfoData.h>
 #include <newbase/NFmiDataIdent.h>
 #include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiInfoData.h>
 #include <newbase/NFmiProducerName.h>
 
 #include <boost/shared_ptr.hpp>
@@ -288,4 +288,3 @@ class NFmiHelpDataInfoSystem
 
   std::string itsBaseNameSpace;
 };
-

--- a/smarttools/NFmiIgnoreStationsData.cpp
+++ b/smarttools/NFmiIgnoreStationsData.cpp
@@ -6,8 +6,8 @@
 // ======================================================================
 
 #include "NFmiIgnoreStationsData.h"
-#include <newbase/NFmiSettings.h>
 #include <newbase/NFmiLocation.h>
+#include <newbase/NFmiSettings.h>
 
 NFmiIgnoreStation::NFmiIgnoreStation(void)
     : itsId(0), itsId2(0), itsName(), itsLastLocationIndex(-1), fEnabled(false)
@@ -48,22 +48,18 @@ std::string NFmiIgnoreStation::MakeStationString(void)
                                           // jos se on tyhjä, laitetaan nimeksi "?"
   usedStationName = NFmiStringTools::ReplaceChars(usedStationName, ';', ',');
   usedStationName = NFmiStringTools::ReplaceChars(usedStationName, ':', '.');
-  if (usedStationName.empty())
-    usedStationName = "?";
-  if (IsRange())
-    usedStationName = "...";
+  if (usedStationName.empty()) usedStationName = "?";
+  if (IsRange()) usedStationName = "...";
   std::stringstream out;
   out << itsId;
-  if (IsRange())
-    out << "-" << itsId2;
+  if (IsRange()) out << "-" << itsId2;
   out << ":" << usedStationName << ":" << fEnabled;  // ':' on erotin aseman tiedoissa
   return out.str();
 }
 
 bool NFmiIgnoreStation::IsRange(void) const
 {
-  if (itsId < itsId2)
-    return true;
+  if (itsId < itsId2) return true;
   return false;
 }
 
@@ -77,10 +73,7 @@ NFmiIgnoreStationsData::NFmiIgnoreStationsData(void)
 {
 }
 
-void NFmiIgnoreStationsData::Clear(void)
-{
-  itsStationList.clear();
-}
+void NFmiIgnoreStationsData::Clear(void) { itsStationList.clear(); }
 
 void NFmiIgnoreStationsData::Add(const NFmiIgnoreStation &theStation)
 {
@@ -149,8 +142,7 @@ std::string NFmiIgnoreStationsData::MakeStationListString(void)
          it != itsStationList.end();
          ++it)
     {
-      if (counter != 0)
-        stationsStr += ";";  // tämä on asemien erotin merkki listassa
+      if (counter != 0) stationsStr += ";";  // tämä on asemien erotin merkki listassa
       stationsStr += (*it).MakeStationString();
       counter++;
     }
@@ -214,8 +206,7 @@ bool NFmiIgnoreStationsData::IsIdInList(unsigned long theStationId)
   {
     if ((*it).IsRange())
     {
-      if (theStationId >= (*it).itsId && theStationId <= (*it).itsId2)
-        return (*it).fEnabled;
+      if (theStationId >= (*it).itsId && theStationId <= (*it).itsId2) return (*it).fEnabled;
     }
     else if ((*it).itsId == theStationId)
       return (*it).fEnabled;

--- a/smarttools/NFmiIgnoreStationsData.h
+++ b/smarttools/NFmiIgnoreStationsData.h
@@ -7,8 +7,8 @@
  */
 // ======================================================================
 
-#include <string>
 #include <list>
+#include <string>
 
 class NFmiLocation;
 

--- a/smarttools/NFmiInfoAreaMaskOccurrance.cpp
+++ b/smarttools/NFmiInfoAreaMaskOccurrance.cpp
@@ -1,9 +1,9 @@
 
 #include "NFmiInfoAreaMaskOccurrance.h"
-#include <newbase/NFmiFastQueryInfo.h>
 #include "NFmiDrawParam.h"
-#include <newbase/NFmiProducerName.h>
 #include "NFmiSmartInfo.h"
+#include <newbase/NFmiFastQueryInfo.h>
+#include <newbase/NFmiProducerName.h>
 
 // **********************************************************
 // *****    NFmiInfoAreaMaskOccurrance  *********************
@@ -14,9 +14,7 @@ std::function<void(checkedVector<boost::shared_ptr<NFmiFastQueryInfo> > &,
                    const boost::shared_ptr<NFmiArea> &)>
     NFmiInfoAreaMaskOccurrance::itsMultiSourceDataGetter;  // Alustetaan tyhjäksi ensin
 
-NFmiInfoAreaMaskOccurrance::~NFmiInfoAreaMaskOccurrance(void)
-{
-}
+NFmiInfoAreaMaskOccurrance::~NFmiInfoAreaMaskOccurrance(void) {}
 NFmiInfoAreaMaskOccurrance::NFmiInfoAreaMaskOccurrance(
     const NFmiCalculationCondition &theOperation,
     Type theMaskType,
@@ -80,8 +78,7 @@ void NFmiInfoAreaMaskOccurrance::Initialize(void)
   {
     boost::shared_ptr<NFmiDrawParam> drawParam(
         new NFmiDrawParam(itsInfo->Param(), *itsInfo->Level(), 0, itsInfo->DataType()));
-    if (fSynopXCase)
-      drawParam->Param().GetProducer()->SetIdent(NFmiInfoData::kFmiSpSynoXProducer);
+    if (fSynopXCase) drawParam->Param().GetProducer()->SetIdent(NFmiInfoData::kFmiSpSynoXProducer);
     itsMultiSourceDataGetter(itsInfoVector, drawParam, itsCalculationArea);
   }
   InitializeLocationIndexCaches();
@@ -127,12 +124,10 @@ bool NFmiInfoAreaMaskOccurrance::IsKnownMultiSourceData()
 {
   if (itsInfo)
   {
-    if (itsInfo->DataType() == NFmiInfoData::kFlashData)
-      return true;
+    if (itsInfo->DataType() == NFmiInfoData::kFlashData) return true;
     // HUOM! kaikkien synop datojen käyttö on aivan liian hidasta, käytetään vain primääri synop
     // dataa laskuissa.
-    if (itsInfo->Producer()->GetIdent() == kFmiSYNOP)
-      return true;
+    if (itsInfo->Producer()->GetIdent() == kFmiSYNOP) return true;
   }
   return false;
 }
@@ -254,14 +249,12 @@ void NFmiInfoAreaMaskOccurrance::DoCalculateCurrentLocation(
       theLocation.Distance(theIsStationLocationsStoredInData ? theInfo->GetLatlonFromData()
                                                              : theInfo->LatLon()) *
       0.001;
-  if (distanceInKM > itsSearchRangeInKM)
-    return;  // kyseinen piste oli ympyrän ulkopuolella
+  if (distanceInKM > itsSearchRangeInKM) return;  // kyseinen piste oli ympyrän ulkopuolella
 
   float value = theInfo->FloatValue();
   if (value != kFloatMissing)
   {
-    if (CheckProbabilityCondition(value))
-      theOccurranceCountInOut++;
+    if (CheckProbabilityCondition(value)) theOccurranceCountInOut++;
   }
 }
 

--- a/smarttools/NFmiInfoAreaMaskOccurrance.h
+++ b/smarttools/NFmiInfoAreaMaskOccurrance.h
@@ -67,7 +67,8 @@ class _FMI_DLL NFmiInfoAreaMaskOccurrance : public NFmiInfoAreaMaskProbFunc
 
   static std::function<void(checkedVector<boost::shared_ptr<NFmiFastQueryInfo>> &,
                             boost::shared_ptr<NFmiDrawParam> &,
-                            const boost::shared_ptr<NFmiArea> &)> itsMultiSourceDataGetter;
+                            const boost::shared_ptr<NFmiArea> &)>
+      itsMultiSourceDataGetter;
 
  private:
   NFmiInfoAreaMaskProbFunc &operator=(const NFmiInfoAreaMaskProbFunc &theMask);

--- a/smarttools/NFmiInfoAreaMaskSoundingIndex.cpp
+++ b/smarttools/NFmiInfoAreaMaskSoundingIndex.cpp
@@ -8,9 +8,7 @@
 #include "NFmiInfoAreaMaskSoundingIndex.h"
 #include <newbase/NFmiFastQueryInfo.h>
 
-NFmiInfoAreaMaskSoundingIndex::~NFmiInfoAreaMaskSoundingIndex(void)
-{
-}
+NFmiInfoAreaMaskSoundingIndex::~NFmiInfoAreaMaskSoundingIndex(void) {}
 
 NFmiInfoAreaMaskSoundingIndex::NFmiInfoAreaMaskSoundingIndex(
     boost::shared_ptr<NFmiFastQueryInfo> &theInfo, FmiSoundingParameters theSoundingParam)

--- a/smarttools/NFmiInfoAreaMaskSoundingIndex.h
+++ b/smarttools/NFmiInfoAreaMaskSoundingIndex.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <newbase/NFmiInfoAreaMask.h>
 #include "NFmiSoundingIndexCalculator.h"
+#include <newbase/NFmiInfoAreaMask.h>
 
 class NFmiFastQueryInfo;
 
@@ -37,4 +37,3 @@ class NFmiInfoAreaMaskSoundingIndex : public NFmiInfoAreaMask
   NFmiInfoAreaMaskSoundingIndex &operator=(const NFmiInfoAreaMaskPeekXY &theMask);
 
 };  // class NFmiInfoAreaMaskSoundingIndex
-

--- a/smarttools/NFmiInfoOrganizer.cpp
+++ b/smarttools/NFmiInfoOrganizer.cpp
@@ -1,14 +1,14 @@
 
 #include "NFmiInfoOrganizer.h"
-#include "NFmiDrawParamFactory.h"
-#include "NFmiSmartInfo.h"
-#include "NFmiQueryDataKeeper.h"
 #include "NFmiDrawParam.h"
-#include <newbase/NFmiQueryInfo.h>
+#include "NFmiDrawParamFactory.h"
+#include "NFmiQueryDataKeeper.h"
+#include "NFmiSmartInfo.h"
+#include <newbase/NFmiFastInfoUtils.h>
 #include <newbase/NFmiGrid.h>
 #include <newbase/NFmiLatLonArea.h>
 #include <newbase/NFmiQueryDataUtil.h>
-#include <newbase/NFmiFastInfoUtils.h>
+#include <newbase/NFmiQueryInfo.h>
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4239)  // poistaa VC++ 2010 varoituksen: warning C4239: nonstandard
@@ -54,9 +54,7 @@ NFmiInfoOrganizer::NFmiInfoOrganizer(void)
   InitializeCheckParams();
 }
 
-NFmiInfoOrganizer::~NFmiInfoOrganizer(void)
-{
-}
+NFmiInfoOrganizer::~NFmiInfoOrganizer(void) {}
 
 bool NFmiInfoOrganizer::Init(const std::string &theDrawParamPath,
                              bool createDrawParamFileIfNotExist,
@@ -108,8 +106,7 @@ bool NFmiInfoOrganizer::AddEditedData(NFmiSmartInfo *theEditedData, int theUndoL
     theEditedData->First();
     try
     {
-      if (theUndoLevel)
-        theEditedData->UndoLevel(theUndoLevel);
+      if (theUndoLevel) theEditedData->UndoLevel(theUndoLevel);
     }
     catch (...)
     {
@@ -197,8 +194,7 @@ static bool CheckDataType(const boost::shared_ptr<NFmiFastQueryInfo> &theInfo,
                           NFmiInfoData::Type theType)
 {
   bool anyDataOk = (theType == NFmiInfoData::kAnyData);
-  if (theInfo && (theInfo->DataType() == theType || anyDataOk))
-    return true;
+  if (theInfo && (theInfo->DataType() == theType || anyDataOk)) return true;
   return false;
 }
 
@@ -227,8 +223,7 @@ static bool CheckDataIdent(const boost::shared_ptr<NFmiFastQueryInfo> &theInfo,
 static bool CheckLevel(const boost::shared_ptr<NFmiFastQueryInfo> &theInfo,
                        const NFmiLevel *theLevel)
 {
-  if (theInfo && (!theLevel || (theLevel && theInfo->Level(*theLevel))))
-    return true;
+  if (theInfo && (!theLevel || (theLevel && theInfo->Level(*theLevel)))) return true;
   return false;
 }
 
@@ -246,8 +241,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::Info(
     tmpDrawParam->ModelRunIndex(0);
     aInfo =
         Info(tmpDrawParam, fCrossSectionInfoWanted);  // koetetaan sitten hakea viimeisintä dataa
-    if (aInfo)
-      fGetDataFromServer = true;
+    if (aInfo) fGetDataFromServer = true;
   }
   return aInfo;
 }
@@ -337,8 +331,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::GetSoundingPlotParamInfo
   // Prioriteetti haku järjestys: 1. Bufr-luotaus, 2. Temp-luotaus
 
   boost::shared_ptr<NFmiFastQueryInfo> soundingInfo = GetWantedProducerInfo(theType, kFmiBufrTEMP);
-  if (!soundingInfo)
-    soundingInfo = GetWantedProducerInfo(theType, kFmiTEMP);
+  if (!soundingInfo) soundingInfo = GetWantedProducerInfo(theType, kFmiTEMP);
   return soundingInfo;
 }
 
@@ -495,8 +488,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::GetInfo(const NFmiDataId
                                  theLevel,
                                  theModelRunIndex,
                                  iter);  // tämä saa olla 0-pointteri, jos kyse oli arkistodatasta
-            if (foundData)
-              break;
+            if (foundData) break;
           }
           else if (backupData == 0)
             backupData = ::DoArchiveCheck(
@@ -505,13 +497,11 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::GetInfo(const NFmiDataId
       }
     }
   }
-  if (foundData == 0 && backupData != 0)
-    foundData = backupData;
+  if (foundData == 0 && backupData != 0) foundData = backupData;
 
   if (foundData)
   {
-    if (foundData->SizeLevels() == 1)
-      foundData->FirstLevel();
+    if (foundData->SizeLevels() == 1) foundData->FirstLevel();
   }
   return foundData;
 }
@@ -551,8 +541,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::CrossSectionInfo(
                                0,
                                theModelRunIndex,
                                iter);  // tämä saa olla 0-pointteri, jos kyse oli arkistodatasta
-          if (foundData)
-            break;
+          if (foundData) break;
         }
         else if (backupData == 0)
           backupData = ::DoArchiveCheck(aInfo,
@@ -567,8 +556,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::CrossSectionInfo(
     }
   }
 
-  if (foundData == 0 && backupData != 0)
-    foundData = backupData;
+  if (foundData == 0 && backupData != 0) foundData = backupData;
 
   return foundData;
 }
@@ -589,8 +577,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::FindInfo(
       boost::shared_ptr<NFmiFastQueryInfo> aInfo = iter->second->GetDataKeeper()->GetIter();
       if (aInfo->DataType() == theDataType)
       {
-        if (ind == theIndex)
-          return aInfo;
+        if (ind == theIndex) return aInfo;
         ind++;
       }
     }
@@ -624,8 +611,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::FindInfo(NFmiInfoData::T
           int levSize = aInfo->SizeLevels();
           if ((levSize == 1 && fGroundData) || (levSize > 1 && (!fGroundData)))
           {
-            if (ind == theIndex)
-              return aInfo;
+            if (ind == theIndex) return aInfo;
             ind++;
           }
         }
@@ -649,16 +635,14 @@ static bool CheckForParams(boost::shared_ptr<NFmiFastQueryInfo> &theInfo,
     size_t paramsFound = 0;
     for (size_t i = 0; i < wantedParams.size(); i++)
     {
-      if (theInfo->Param(wantedParams[i]))
-        paramsFound++;
+      if (theInfo->Param(wantedParams[i])) paramsFound++;
     }
 
     if (trajectorySpecial)  // trajektori parametreista pitää olla kolme neljästä, muuten laskuja ei
     // tehdä ollenkaan (tämä ei ole täydellinen tarkistus, koska pitää olla
     // WS, WD ja toinen w -parametreista)
     {
-      if (paramsFound >= wantedParams.size() - 1)
-        return true;
+      if (paramsFound >= wantedParams.size() - 1) return true;
     }
     else if (paramsFound)
       return true;
@@ -678,8 +662,7 @@ bool NFmiInfoOrganizer::IsTempData(boost::shared_ptr<NFmiFastQueryInfo> &theInfo
 // Luotaus-dialogin TEMP-syöttö dialogista.
 bool NFmiInfoOrganizer::IsTempData(unsigned long theProducerId, bool includeRawTemp)
 {
-  if (includeRawTemp && theProducerId == kFmiRAWTEMP)
-    return true;
+  if (includeRawTemp && theProducerId == kFmiRAWTEMP) return true;
   if (theProducerId == kFmiTEMP || theProducerId == kFmiBufrTEMP)
     return true;
   else
@@ -696,8 +679,7 @@ int NFmiInfoOrganizer::CalcWantedParameterCount(
     FmiParameterName oldParamId = static_cast<FmiParameterName>(info->Param().GetParamIdent());
     for (size_t i = 0; i < wantedParameters.size(); i++)
     {
-      if (info->Param(wantedParameters[i]))
-        counter++;
+      if (info->Param(wantedParameters[i])) counter++;
     }
     info->Param(oldParamId);
   }
@@ -758,8 +740,9 @@ int NFmiInfoOrganizer::IsGoodSoundingData(boost::shared_ptr<NFmiFastQueryInfo> &
       if (theInfo->SizeLevels() >
           3)  // pitää olla väh 4 leveliä ennen kuin kelpuutetaan sounding dataksi
       {
-        // Datassa pitää olla tiettyjä parametreja, että se kelpaa luotaukseen, ja liikkuvat 
-        // luotaukset ovat poikkeus, ne pitää päästää läpi myös, koska niilla ei ole muka 'vertikaali' dataa
+        // Datassa pitää olla tiettyjä parametreja, että se kelpaa luotaukseen, ja liikkuvat
+        // luotaukset ovat poikkeus, ne pitää päästää läpi myös, koska niilla ei ole muka
+        // 'vertikaali' dataa
         if (HasGoodParamsForSoundingData(theInfo, paramCheckFlags) ||
             NFmiFastInfoUtils::IsMovingSoundingData(theInfo))
         {
@@ -774,13 +757,13 @@ int NFmiInfoOrganizer::IsGoodSoundingData(boost::shared_ptr<NFmiFastQueryInfo> &
   return 0;
 }
 
-static bool IsGivenTimeInDataRange(const boost::shared_ptr<NFmiFastQueryInfo> &info, const NFmiMetTime &wantedDataTime)
+static bool IsGivenTimeInDataRange(const boost::shared_ptr<NFmiFastQueryInfo> &info,
+                                   const NFmiMetTime &wantedDataTime)
 {
-    if(!info)
-        return false;
-    if(wantedDataTime == NFmiMetTime::gMissingTime)
-        return true; // with missing-time we don't care if time in data's range
-    return info->TimeDescriptor().IsInside(wantedDataTime);
+  if (!info) return false;
+  if (wantedDataTime == NFmiMetTime::gMissingTime)
+    return true;  // with missing-time we don't care if time in data's range
+  return info->TimeDescriptor().IsInside(wantedDataTime);
 }
 
 // Hakee parhaan luotaus infon tuottajalle. Eli jos kyseessä esim hirlam tuottaja, katsotaan
@@ -789,22 +772,21 @@ static bool IsGivenTimeInDataRange(const boost::shared_ptr<NFmiFastQueryInfo> &i
 boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::FindSoundingInfo(
     const NFmiProducer &theProducer, int theIndex, ParamCheckFlags paramCheckFlags)
 {
-    return FindSoundingInfo(theProducer, NFmiMetTime::gMissingTime, theIndex, paramCheckFlags);
+  return FindSoundingInfo(theProducer, NFmiMetTime::gMissingTime, theIndex, paramCheckFlags);
 }
 
 boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::FindSoundingInfo(
-        const NFmiProducer &theProducer,
-        const NFmiMetTime &theDataTime,
-        int theIndex,
-        ParamCheckFlags paramCheckFlags)
+    const NFmiProducer &theProducer,
+    const NFmiMetTime &theDataTime,
+    int theIndex,
+    ParamCheckFlags paramCheckFlags)
 {
   boost::shared_ptr<NFmiFastQueryInfo> exceptableInfo;
   for (MapType::iterator iter = itsDataMap.begin(); iter != itsDataMap.end(); ++iter)
   {
     boost::shared_ptr<NFmiFastQueryInfo> aInfo = iter->second->GetDataKeeper()->GetIter();
     int result = IsGoodSoundingData(aInfo, theProducer, false, paramCheckFlags);
-    if(!::IsGivenTimeInDataRange(aInfo, theDataTime))
-        result = 0;
+    if (!::IsGivenTimeInDataRange(aInfo, theDataTime)) result = 0;
     if (result != 0 && theIndex < 0)
     {  // haetaan vanhempaa malliajo dataa
       boost::shared_ptr<NFmiQueryDataKeeper> qDataKeeper = iter->second->GetDataKeeper(theIndex);
@@ -823,8 +805,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::FindSoundingInfo(
     }
   }
 
-  if (exceptableInfo)
-    return exceptableInfo;
+  if (exceptableInfo) return exceptableInfo;
 
   boost::shared_ptr<NFmiFastQueryInfo> aInfo = FindInfo(NFmiInfoData::kEditable);
   if (aInfo)
@@ -834,8 +815,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::FindSoundingInfo(
          theProducer))  // tässä hanskataan 'editoitu' data, jolloin ignoorataan tuottaja
     {
       int result = IsGoodSoundingData(aInfo, theProducer, true, paramCheckFlags);
-      if (result != 0)
-        exceptableInfo = aInfo;
+      if (result != 0) exceptableInfo = aInfo;
     }
   }
 
@@ -851,8 +831,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::GetPrioritizedSoundingIn
   if (info == 0)
   {
     info = FindSoundingInfo(NFmiProducer(kFmiBufrTEMP), 0, paramCheckFlags);
-    if (info == 0)
-      info = FindSoundingInfo(NFmiProducer(kFmiTEMP), 0, paramCheckFlags);
+    if (info == 0) info = FindSoundingInfo(NFmiProducer(kFmiTEMP), 0, paramCheckFlags);
   }
   return info;
 }
@@ -955,14 +934,12 @@ checkedVector<boost::shared_ptr<NFmiFastQueryInfo> > NFmiInfoOrganizer::GetInfos
   if (theType == NFmiInfoData::kEditable)
   {
     boost::shared_ptr<NFmiFastQueryInfo> info = itsEditedDataKeeper->GetIter();
-    if (info)
-      infoVector.push_back(itsEditedDataKeeper->GetIter());
+    if (info) infoVector.push_back(itsEditedDataKeeper->GetIter());
   }
   else if (theType == NFmiInfoData::kCopyOfEdited)
   {
     boost::shared_ptr<NFmiFastQueryInfo> info = itsCopyOfEditedDataKeeper->GetIter();
-    if (info)
-      infoVector.push_back(itsEditedDataKeeper->GetIter());
+    if (info) infoVector.push_back(itsEditedDataKeeper->GetIter());
   }
   else
   {
@@ -996,23 +973,20 @@ checkedVector<boost::shared_ptr<NFmiFastQueryInfo> > NFmiInfoOrganizer::GetInfos
   if (itsEditedDataKeeper && theDataType == NFmiInfoData::kEditable)
   {
     boost::shared_ptr<NFmiFastQueryInfo> editedDataIter = itsEditedDataKeeper->GetIter();
-    if (editedDataIter)
-      infoVector.push_back(editedDataIter);
+    if (editedDataIter) infoVector.push_back(editedDataIter);
   }
   else if (itsCopyOfEditedDataKeeper && theDataType == NFmiInfoData::kCopyOfEdited)
   {
     boost::shared_ptr<NFmiFastQueryInfo> copyOfEditedDataIter =
         itsCopyOfEditedDataKeeper->GetIter();
-    if (copyOfEditedDataIter)
-      infoVector.push_back(copyOfEditedDataIter);
+    if (copyOfEditedDataIter) infoVector.push_back(copyOfEditedDataIter);
   }
   else
   {
     for (MapType::iterator iter = itsDataMap.begin(); iter != itsDataMap.end(); ++iter)
     {
       boost::shared_ptr<NFmiFastQueryInfo> info = iter->second->GetDataKeeper()->GetIter();
-      if (info->DataType() == theDataType)
-        infoVector.push_back(info);
+      if (info->DataType() == theDataType) infoVector.push_back(info);
     }
   }
   return infoVector;
@@ -1063,8 +1037,7 @@ boost::shared_ptr<NFmiDrawParam> NFmiInfoOrganizer::CreateDrawParam(const NFmiDa
     return CreateSynopPlotDrawParam(theIdent, theLevel, theType);
   }
   drawParam = itsDrawParamFactory->CreateDrawParam(theIdent, theLevel);
-  if (drawParam)
-    drawParam->DataType(theType);  // data tyyppi pitää myös asettaa!!
+  if (drawParam) drawParam->DataType(theType);  // data tyyppi pitää myös asettaa!!
   return drawParam;
 }
 
@@ -1074,8 +1047,7 @@ boost::shared_ptr<NFmiDrawParam> NFmiInfoOrganizer::CreateCrossSectionDrawParam(
 {
   boost::shared_ptr<NFmiDrawParam> drawParam =
       itsDrawParamFactory->CreateCrossSectionDrawParam(theDataIdent);
-  if (drawParam)
-    drawParam->DataType(theType);  // data tyyppi pitää myös asettaa!!
+  if (drawParam) drawParam->DataType(theType);  // data tyyppi pitää myös asettaa!!
   return drawParam;
 }
 
@@ -1092,8 +1064,7 @@ boost::shared_ptr<NFmiDrawParam> NFmiInfoOrganizer::CreateSynopPlotDrawParam(
   boost::shared_ptr<NFmiDrawParam> drawParam = itsDrawParamFactory->CreateDrawParam(
       usedDataIdent,
       theLevel);  // false merkitsee, että parametria ei taas aseteta tuolla metodissa
-  if (drawParam)
-    drawParam->DataType(theType);
+  if (drawParam) drawParam->DataType(theType);
   return drawParam;
 }
 
@@ -1120,8 +1091,7 @@ void NFmiInfoOrganizer::ClearData(NFmiInfoData::Type theDataType)
     MapType::iterator iter = itsDataMap.begin();
     for (;;)
     {
-      if (iter == itsDataMap.end())
-        break;
+      if (iter == itsDataMap.end()) break;
 
       if (iter->second->GetDataKeeper()->GetIter()->DataType() == theDataType)
       {
@@ -1183,8 +1153,7 @@ bool NFmiInfoOrganizer::IsInfosTwoOfTheKind(NFmiQueryInfo *theInfo1,
           {
             theInfo1->FirstParam();  // varmistaa, että producer löytyy
             theInfo2->FirstParam();
-            if (*theInfo1->Producer() == *theInfo2->Producer())
-              return true;
+            if (*theInfo1->Producer() == *theInfo2->Producer()) return true;
           }
         }
       }
@@ -1262,15 +1231,13 @@ void NFmiInfoOrganizer::ClearDynamicHelpData()
 
 void NFmiInfoOrganizer::SetDrawParamPath(const std::string &theDrawParamPath)
 {
-  if (itsDrawParamFactory)
-    itsDrawParamFactory->LoadDirectory(theDrawParamPath);
+  if (itsDrawParamFactory) itsDrawParamFactory->LoadDirectory(theDrawParamPath);
 }
 
 const std::string NFmiInfoOrganizer::GetDrawParamPath(void)
 {
   std::string retValue;
-  if (itsDrawParamFactory)
-    retValue = itsDrawParamFactory->LoadDirectory();
+  if (itsDrawParamFactory) retValue = itsDrawParamFactory->LoadDirectory();
   return retValue;
 }
 
@@ -1362,10 +1329,8 @@ void NFmiInfoOrganizer::UpdateCrossSectionMacroParamDataSize(int x, int y)
 int NFmiInfoOrganizer::CountData(void)
 {
   int count = 0;
-  if (itsEditedDataKeeper)
-    count++;
-  if (itsCopyOfEditedDataKeeper)
-    count++;
+  if (itsEditedDataKeeper) count++;
+  if (itsCopyOfEditedDataKeeper) count++;
 
   for (MapType::iterator iter = itsDataMap.begin(); iter != itsDataMap.end(); ++iter)
     count += static_cast<int>(iter->second->DataCount());
@@ -1376,8 +1341,7 @@ int NFmiInfoOrganizer::CountData(void)
 double NFmiInfoOrganizer::CountDataSize(void)
 {
   double dataSize = 0;
-  if (itsEditedDataKeeper)
-    dataSize += itsEditedDataKeeper->OriginalData()->Size() * sizeof(float);
+  if (itsEditedDataKeeper) dataSize += itsEditedDataKeeper->OriginalData()->Size() * sizeof(float);
   if (itsCopyOfEditedDataKeeper)
     dataSize += itsCopyOfEditedDataKeeper->OriginalData()->Size() * sizeof(float);
 
@@ -1431,16 +1395,13 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiInfoOrganizer::DoDynamicShallowCopy(
   if (theInfo)
   {
     NFmiSmartInfo *smartInfo = dynamic_cast<NFmiSmartInfo *>(theInfo.get());
-    if (smartInfo)
-      return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiSmartInfo(*smartInfo));
+    if (smartInfo) return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiSmartInfo(*smartInfo));
 
     NFmiOwnerInfo *ownerInfo = dynamic_cast<NFmiOwnerInfo *>(theInfo.get());
-    if (ownerInfo)
-      return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiOwnerInfo(*ownerInfo));
+    if (ownerInfo) return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiOwnerInfo(*ownerInfo));
 
     NFmiFastQueryInfo *fastInfo = dynamic_cast<NFmiFastQueryInfo *>(theInfo.get());
-    if (fastInfo)
-      return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiFastQueryInfo(*fastInfo));
+    if (fastInfo) return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiFastQueryInfo(*fastInfo));
   }
 
   return boost::shared_ptr<NFmiFastQueryInfo>();

--- a/smarttools/NFmiInfoOrganizer.h
+++ b/smarttools/NFmiInfoOrganizer.h
@@ -22,12 +22,12 @@
 // TODO: keksi parempi nimi tai muuta lopuksi NFmiInfoOrganizer-nimiseksi ja
 // tuhoa alkuperäinen luokka.
 
-#include <newbase/NFmiPoint.h>
+#include <boost/shared_ptr.hpp>
 #include <newbase/NFmiDataMatrix.h>
 #include <newbase/NFmiInfoData.h>
 #include <newbase/NFmiParamBag.h>
+#include <newbase/NFmiPoint.h>
 #include <newbase/NFmiProducerName.h>
-#include <boost/shared_ptr.hpp>
 #include <map>
 
 class NFmiSmartInfo;
@@ -147,7 +147,7 @@ class NFmiInfoOrganizer
       const NFmiMetTime &theDataTime,
       int theIndex = 0,
       ParamCheckFlags paramCheckFlags =
-      ParamCheckFlags());  // Hakee parhaan luotaus infon tuottajalle
+          ParamCheckFlags());  // Hakee parhaan luotaus infon tuottajalle
   boost::shared_ptr<NFmiFastQueryInfo> GetPrioritizedSoundingInfo(
       ParamCheckFlags paramCheckFlags =
           ParamCheckFlags());  // Hakee tietyn prioriteetin mukaisesti parhaan luotaus-infon

--- a/smarttools/NFmiModifiableQDatasBookKeeping.cpp
+++ b/smarttools/NFmiModifiableQDatasBookKeeping.cpp
@@ -1,9 +1,9 @@
 // NFmiModifiableQDatasBookKeeping
 
 #include "NFmiModifiableQDatasBookKeeping.h"
-#include "NFmiUndoableMultiLevelMask.h"
 #include "NFmiMultiLevelMask.h"
 #include "NFmiUndoRedoQData.h"
+#include "NFmiUndoableMultiLevelMask.h"
 
 NFmiModifiableQDatasBookKeeping::NFmiModifiableQDatasBookKeeping(unsigned long theMaskSize)
     : itsAreaMask(theMaskSize ? new NFmiUndoableMultiLevelMask(theMaskSize) : 0),
@@ -28,14 +28,10 @@ void NFmiModifiableQDatasBookKeeping::CopyClonedDatas(
   {
     // HUOM! Tässä kopioidaan dataa vain this:issa oleviin ei 0-pointtereihin.
     // Eli ei luoda uusia olioita tässä, kuten ehkä normaalisti sijoitus operaatiossa tehtäisiin.
-    if (itsUndoRedoQData)
-      *itsUndoRedoQData = *(theOther.itsUndoRedoQData);
-    if (itsAreaMask)
-      *itsAreaMask = *(theOther.itsAreaMask);
-    if (fLoadedFromFile)
-      *fLoadedFromFile = *(theOther.fLoadedFromFile);
-    if (fDirty)
-      *fDirty = *(theOther.fDirty);
+    if (itsUndoRedoQData) *itsUndoRedoQData = *(theOther.itsUndoRedoQData);
+    if (itsAreaMask) *itsAreaMask = *(theOther.itsAreaMask);
+    if (fLoadedFromFile) *fLoadedFromFile = *(theOther.fLoadedFromFile);
+    if (fDirty) *fDirty = *(theOther.fDirty);
   }
 }
 
@@ -67,16 +63,14 @@ unsigned long NFmiModifiableQDatasBookKeeping::LocationMaskedCount(unsigned long
 
 bool NFmiModifiableQDatasBookKeeping::Mask(const NFmiBitMask& theMask, unsigned long theMaskType)
 {
-  if (itsAreaMask)
-    return itsAreaMask->Mask(theMask, theMaskType);
+  if (itsAreaMask) return itsAreaMask->Mask(theMask, theMaskType);
 
   return false;
 }
 
 const NFmiBitMask& NFmiModifiableQDatasBookKeeping::Mask(unsigned long theMaskType) const
 {
-  if (itsAreaMask)
-    return itsAreaMask->Mask(theMaskType);
+  if (itsAreaMask) return itsAreaMask->Mask(theMaskType);
 
   throw std::runtime_error("Error in application - NFmiSmartInfo::Mask has no mask.");
 }
@@ -93,10 +87,7 @@ void NFmiModifiableQDatasBookKeeping::MaskType(unsigned long theMaskType)
   (*itsAreaMask)->MaskType(theMaskType);
 }
 
-unsigned long NFmiModifiableQDatasBookKeeping::MaskType(void)
-{
-  return (*itsAreaMask)->MaskType();
-}
+unsigned long NFmiModifiableQDatasBookKeeping::MaskType(void) { return (*itsAreaMask)->MaskType(); }
 
 bool NFmiModifiableQDatasBookKeeping::IsMasked(unsigned long theIndex) const
 {
@@ -116,15 +107,13 @@ bool NFmiModifiableQDatasBookKeeping::SnapShotData(
 
 bool NFmiModifiableQDatasBookKeeping::Undo(void)
 {
-  if (itsUndoRedoQData)
-    return itsUndoRedoQData->Undo();
+  if (itsUndoRedoQData) return itsUndoRedoQData->Undo();
   return false;
 }
 
 bool NFmiModifiableQDatasBookKeeping::Redo(void)
 {
-  if (itsUndoRedoQData)
-    return itsUndoRedoQData->Redo();
+  if (itsUndoRedoQData) return itsUndoRedoQData->Redo();
   return false;
 }
 
@@ -167,8 +156,7 @@ void NFmiModifiableQDatasBookKeeping::UndoLevel(long theDepth, const NFmiRawData
   }
   else
   {
-    if (itsUndoRedoQData == 0)
-      itsUndoRedoQData = new NFmiUndoRedoQData;
+    if (itsUndoRedoQData == 0) itsUndoRedoQData = new NFmiUndoRedoQData;
 
     itsUndoRedoQData->UndoLevel(theDepth, theRawData);
   }
@@ -188,15 +176,9 @@ bool NFmiModifiableQDatasBookKeeping::LocationSelectionSnapShot(void)
   return itsAreaMask->SnapShotData();
 }
 
-bool NFmiModifiableQDatasBookKeeping::LocationSelectionUndo(void)
-{
-  return itsAreaMask->Undo();
-}
+bool NFmiModifiableQDatasBookKeeping::LocationSelectionUndo(void) { return itsAreaMask->Undo(); }
 
-bool NFmiModifiableQDatasBookKeeping::LocationSelectionRedo(void)
-{
-  return itsAreaMask->Redo();
-}
+bool NFmiModifiableQDatasBookKeeping::LocationSelectionRedo(void) { return itsAreaMask->Redo(); }
 
 bool NFmiModifiableQDatasBookKeeping::LocationSelectionUndoData(void)
 {

--- a/smarttools/NFmiMultiLevelMask.cpp
+++ b/smarttools/NFmiMultiLevelMask.cpp
@@ -67,17 +67,12 @@ NFmiMultiLevelMask& NFmiMultiLevelMask::operator=(const NFmiMultiLevelMask& theM
   return *this;
 }
 
-NFmiMultiLevelMask::~NFmiMultiLevelMask(void)
-{
-}
+NFmiMultiLevelMask::~NFmiMultiLevelMask(void) {}
 
 //--------------------------------------------------------
 // MaskSize
 //--------------------------------------------------------
-const unsigned long& NFmiMultiLevelMask::MaskSize(void) const
-{
-  return itsMaskSize;
-}
+const unsigned long& NFmiMultiLevelMask::MaskSize(void) const { return itsMaskSize; }
 
 //--------------------------------------------------------
 // Mask
@@ -88,8 +83,7 @@ const unsigned long& NFmiMultiLevelMask::MaskSize(void) const
 //   itsMaskType:n arvosta.
 void NFmiMultiLevelMask::Mask(unsigned long theIndex, bool theNewState)
 {
-  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return;
+  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return;
   if ((itsMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
       NFmiMetEditorTypes::kFmiSelectionMask)
     itsSelectionMask.Mask(theIndex, theNewState);
@@ -111,16 +105,13 @@ void NFmiMultiLevelMask::Mask(unsigned long theIndex, bool theNewState)
 //
 bool NFmiMultiLevelMask::IsMasked(unsigned long theIndex) const
 {
-  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return true;
+  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return true;
   if ((itsMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
       NFmiMetEditorTypes::kFmiSelectionMask)
-    if (!itsSelectionMask.IsMasked(theIndex))
-      return false;
+    if (!itsSelectionMask.IsMasked(theIndex)) return false;
   if ((itsMaskType & NFmiMetEditorTypes::kFmiDisplayedMask) ==
       NFmiMetEditorTypes::kFmiDisplayedMask)
-    if (!itsDisplayedMask.IsMasked(theIndex))
-      return false;
+    if (!itsDisplayedMask.IsMasked(theIndex)) return false;
   if ((itsMaskType & 0xffffffff) == 0)  // Jos mitään maaskityyppiä ei ole valittu.
     return false;                       // Tämä on käyttäjän aiheuttama virhetila.
   return true;
@@ -132,8 +123,7 @@ bool NFmiMultiLevelMask::IsMasked(unsigned long theIndex) const
 //   .
 void NFmiMultiLevelMask::Mask(unsigned long theIndex, bool theNewState, unsigned long theMaskType)
 {
-  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return;
+  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return;
   if ((theMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
       NFmiMetEditorTypes::kFmiSelectionMask)
     itsSelectionMask.Mask(theIndex, theNewState);
@@ -147,18 +137,14 @@ void NFmiMultiLevelMask::Mask(unsigned long theIndex, bool theNewState, unsigned
 //--------------------------------------------------------
 bool NFmiMultiLevelMask::IsMasked(unsigned long theIndex, unsigned long theMaskType) const
 {
-  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return true;
+  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return true;
   if ((theMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
       NFmiMetEditorTypes::kFmiSelectionMask)
-    if (!itsSelectionMask.IsMasked(theIndex))
-      return false;
+    if (!itsSelectionMask.IsMasked(theIndex)) return false;
   if ((theMaskType & NFmiMetEditorTypes::kFmiDisplayedMask) ==
       NFmiMetEditorTypes::kFmiDisplayedMask)
-    if (!itsDisplayedMask.IsMasked(theIndex))
-      return false;
-  if ((theMaskType & 0xffffffff) == 0)
-    return false;  // Tämä on käyttäjän aiheuttama virhetila.
+    if (!itsDisplayedMask.IsMasked(theIndex)) return false;
+  if ((theMaskType & 0xffffffff) == 0) return false;  // Tämä on käyttäjän aiheuttama virhetila.
   return true;
 }
 //--------------------------------------------------------
@@ -172,8 +158,7 @@ bool NFmiMultiLevelMask::IsMasked(unsigned long theIndex, unsigned long theMaskT
 //   kaikki arvot newStaten mukaisiksi.
 void NFmiMultiLevelMask::MaskAll(bool theNewState)
 {
-  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return;
+  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return;
   if ((itsMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
       NFmiMetEditorTypes::kFmiSelectionMask)
     itsSelectionMask.Mask(theNewState);
@@ -187,8 +172,7 @@ void NFmiMultiLevelMask::MaskAll(bool theNewState)
 //--------------------------------------------------------
 void NFmiMultiLevelMask::MaskAll(bool theNewState, unsigned long theMaskType)
 {
-  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return;
+  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return;
   if ((theMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
       NFmiMetEditorTypes::kFmiSelectionMask)
     itsSelectionMask.Mask(theNewState);
@@ -200,8 +184,7 @@ void NFmiMultiLevelMask::MaskAll(bool theNewState, unsigned long theMaskType)
 
 void NFmiMultiLevelMask::InverseMask(unsigned long theMaskType)
 {
-  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return;
+  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return;
   if ((theMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
       NFmiMetEditorTypes::kFmiSelectionMask)
     itsSelectionMask.InverseMask();
@@ -221,8 +204,7 @@ void NFmiMultiLevelMask::InverseMask(unsigned long theMaskType)
 //   koko operaatio.
 bool NFmiMultiLevelMask::Mask(const NFmiBitMask& theMask)
 {
-  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return true;
+  if ((itsMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return true;
   if (itsMaskSize == static_cast<unsigned long>(theMask.Size()))
   {
     if ((itsMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
@@ -244,8 +226,7 @@ bool NFmiMultiLevelMask::Mask(const NFmiBitMask& theMask)
 //   maskeihin.
 bool NFmiMultiLevelMask::Mask(const NFmiBitMask& theMask, unsigned long theMaskType)
 {
-  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask)
-    return true;
+  if ((theMaskType & NFmiMetEditorTypes::kFmiNoMask) == NFmiMetEditorTypes::kFmiNoMask) return true;
   if (itsMaskSize == static_cast<unsigned long>(theMask.Size()))
   {
     if ((theMaskType & NFmiMetEditorTypes::kFmiSelectionMask) ==
@@ -275,12 +256,9 @@ const NFmiBitMask& NFmiMultiLevelMask::Mask(unsigned long theMaskType) const
 
 unsigned long NFmiMultiLevelMask::MaskedCount(unsigned long theMaskType)
 {
-  if (theMaskType == NFmiMetEditorTypes::kFmiNoMask)
-    return itsMaskSize;
-  if (theMaskType == NFmiMetEditorTypes::kFmiSelectionMask)
-    return itsSelectionMask.MaskedCount();
-  if (theMaskType == NFmiMetEditorTypes::kFmiDisplayedMask)
-    return itsDisplayedMask.MaskedCount();
+  if (theMaskType == NFmiMetEditorTypes::kFmiNoMask) return itsMaskSize;
+  if (theMaskType == NFmiMetEditorTypes::kFmiSelectionMask) return itsSelectionMask.MaskedCount();
+  if (theMaskType == NFmiMetEditorTypes::kFmiDisplayedMask) return itsDisplayedMask.MaskedCount();
 
   return 0;
 }
@@ -313,8 +291,7 @@ int NFmiMultiLevelMask::MaskedCount(unsigned long theMaskType,
       else
       {
         unsigned long index = i * theXGridSize + j;
-        if (IsMasked(index, theMaskType))
-          count++;
+        if (IsMasked(index, theMaskType)) count++;
       }
     }
   }

--- a/smarttools/NFmiMultiLevelMask.h
+++ b/smarttools/NFmiMultiLevelMask.h
@@ -72,4 +72,3 @@ class NFmiMultiLevelMask
   unsigned long itsMaskType;
   unsigned long itsMaskSize;  //    NFmiBitmask:ien koko.
 };
-

--- a/smarttools/NFmiOwnerInfo.cpp
+++ b/smarttools/NFmiOwnerInfo.cpp
@@ -30,9 +30,7 @@ NFmiOwnerInfo::NFmiOwnerInfo(const NFmiOwnerInfo &theInfo)
 {
 }
 
-NFmiOwnerInfo::~NFmiOwnerInfo(void)
-{
-}
+NFmiOwnerInfo::~NFmiOwnerInfo(void) {}
 
 NFmiOwnerInfo &NFmiOwnerInfo::operator=(const NFmiOwnerInfo &theInfo)
 {

--- a/smarttools/NFmiOwnerInfo.h
+++ b/smarttools/NFmiOwnerInfo.h
@@ -7,8 +7,8 @@
 // ns. InfoOrganizer-luokkaan talteen, mistä eri datojen infoja pyydetään.
 // TODO: Keksi luokalle parempi nimi.
 
-#include <newbase/NFmiFastQueryInfo.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiFastQueryInfo.h>
 
 class NFmiOwnerInfo : public NFmiFastQueryInfo
 {
@@ -35,6 +35,7 @@ class NFmiOwnerInfo : public NFmiFastQueryInfo
   }
 
   boost::shared_ptr<NFmiQueryData> DataReference(void) { return itsDataPtr; }
+
  protected:
   boost::shared_ptr<NFmiQueryData> itsDataPtr;
   std::string itsDataFileName;

--- a/smarttools/NFmiProducerSystem.cpp
+++ b/smarttools/NFmiProducerSystem.cpp
@@ -8,9 +8,9 @@
 //---------------------------------------------------------- NFmiWarningCenterSystem.h
 
 #include "NFmiProducerSystem.h"
-#include <newbase/NFmiSettings.h>
-#include <newbase/NFmiMetTime.h>
 #include <newbase/NFmiLevel.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiSettings.h>
 
 const std::string &NFmiProducerInfo::ShortName(size_t index) const
 {
@@ -38,10 +38,7 @@ void NFmiProducerInfo::SetShortNames(const std::string &newShortNames)
                            itsShortNameVector.end());
 }
 
-NFmiProducer NFmiProducerInfo::GetProducer(void)
-{
-  return NFmiProducer(itsProducerId, itsName);
-}
+NFmiProducer NFmiProducerInfo::GetProducer(void) { return NFmiProducer(itsProducerId, itsName); }
 
 NFmiProducerInfo NFmiProducerSystem::GetProducerInfoFromSettings(
     const std::string &theUsedNameSpaceBase)
@@ -132,8 +129,7 @@ void NFmiProducerSystem::InitFromSettings(const std::string &theInitNameSpace)
 bool NFmiProducerSystem::ExistProducer(unsigned int index1Based) const
 {
   // jos annettu indeksi on 0, o-1 -> 4 miljardia unsigned maailmassa, joten riittää yksi testi
-  if (index1Based - 1 < itsProducers.size())
-    return true;
+  if (index1Based - 1 < itsProducers.size()) return true;
   return false;
 }
 
@@ -170,8 +166,7 @@ NFmiString NFmiProducerSystem::GetProducerAndLevelTypeString(const NFmiProducer 
                                                              bool fEncloseInBracers)
 {
   NFmiString txt;
-  if (fEncloseInBracers)
-    txt += "(";
+  if (fEncloseInBracers) txt += "(";
 
   // etsi mallin nimi
   unsigned int modelIndex = FindProducerInfo(theProducer);
@@ -189,8 +184,7 @@ NFmiString NFmiProducerSystem::GetProducerAndLevelTypeString(const NFmiProducer 
   else
     txt += "sfc";
 
-  if (fEncloseInBracers)
-    txt += ")";
+  if (fEncloseInBracers) txt += ")";
 
   return txt;
 }

--- a/smarttools/NFmiProducerSystem.h
+++ b/smarttools/NFmiProducerSystem.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
+#include <newbase/NFmiInfoData.h>
 #include <newbase/NFmiProducer.h>
 #include <newbase/NFmiProducerName.h>
-#include <newbase/NFmiInfoData.h>
 #include <string>
 #include <vector>
 
@@ -52,6 +52,7 @@ class NFmiProducerInfo
   void HasRealVerticalData(bool newValue) { fHasRealVerticalData = newValue; }
   bool HasQ2ArchiveData(void) const { return fHasQ2ArchiveData; }
   void HasQ2ArchiveData(bool newValue) { fHasQ2ArchiveData = newValue; }
+
  private:
   std::string itsName;  // Pitempi nimi esim. Hirlam tai Ecmwf (voidaan käyttää esim.
                         // popup-valikoissa, missä on tilaa)
@@ -139,4 +140,3 @@ struct NFmiProducerHelperInfo
   NFmiInfoData::Type itsDataType;
   bool fGroundData;
 };
-

--- a/smarttools/NFmiQueryDataKeeper.cpp
+++ b/smarttools/NFmiQueryDataKeeper.cpp
@@ -1,8 +1,8 @@
 
 #include "NFmiQueryDataKeeper.h"
 #include "NFmiSmartInfo.h"
-#include <newbase/NFmiFileSystem.h>
 #include <newbase/NFmiFileString.h>
+#include <newbase/NFmiFileSystem.h>
 #include <newbase/NFmiQueryData.h>
 #include <fstream>
 
@@ -42,9 +42,7 @@ NFmiQueryDataKeeper::NFmiQueryDataKeeper(boost::shared_ptr<NFmiOwnerInfo> &theOr
 {
 }
 
-NFmiQueryDataKeeper::~NFmiQueryDataKeeper(void)
-{
-}
+NFmiQueryDataKeeper::~NFmiQueryDataKeeper(void) {}
 
 boost::shared_ptr<NFmiOwnerInfo> NFmiQueryDataKeeper::OriginalData(void)
 {
@@ -63,8 +61,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiQueryDataKeeper::GetIter(void)
   // Katsotaan onko listassa yhtään Info-iteraattoria, joka ei ole käytössä (ref-count = 1)
   for (size_t i = 0; i < itsIteratorList.size(); i++)
   {
-    if (itsIteratorList[i].use_count() <= 1)
-      return itsIteratorList[i];
+    if (itsIteratorList[i].use_count() <= 1) return itsIteratorList[i];
   }
 
   // Ei löytynyt vapaata (tai ollenkaan) Info-iteraattoria, pitää luoda sellainen ja lisätä listaan
@@ -119,9 +116,7 @@ NFmiQueryDataSetKeeper::NFmiQueryDataSetKeeper(boost::shared_ptr<NFmiOwnerInfo> 
   AddData(theData, true, dataWasDeleted);  // true tarkoittaa että kyse on 1. lisättävästä datasta
 }
 
-NFmiQueryDataSetKeeper::~NFmiQueryDataSetKeeper(void)
-{
-}
+NFmiQueryDataSetKeeper::~NFmiQueryDataSetKeeper(void) {}
 /*
 static void QDataListDestroyer(NFmiQueryDataSetKeeper::ListType *theQDataListToBeDestroyed)
 {
@@ -225,8 +220,7 @@ bool NFmiQueryDataSetKeeper::OrigTimeDataExist(const NFmiMetTime &theOrigTime)
 {
   for (ListType::iterator it = itsQueryDatas.begin(); it != itsQueryDatas.end(); ++it)
   {
-    if ((*it)->OriginTime() == theOrigTime)
-      return true;
+    if ((*it)->OriginTime() == theOrigTime) return true;
   }
   return false;
 }
@@ -235,8 +229,7 @@ static int CalcIndex(const NFmiMetTime &theLatestOrigTime,
                      const NFmiMetTime &theOrigCurrentTime,
                      int theModelRunTimeGap)
 {
-  if (theModelRunTimeGap == 0)
-    return 0;
+  if (theModelRunTimeGap == 0) return 0;
   int diffInMinutes = theLatestOrigTime.DifferenceInMinutes(theOrigCurrentTime);
   return static_cast<int>(round(-diffInMinutes / theModelRunTimeGap));
 }
@@ -273,8 +266,7 @@ struct OldDataRemover
   OldDataRemover(int theMaxLatestDataCount) : itsMaxLatestDataCount(theMaxLatestDataCount) {}
   bool operator()(boost::shared_ptr<NFmiQueryDataKeeper> &theDataKeeper)
   {
-    if (::abs(theDataKeeper->Index()) > itsMaxLatestDataCount)
-      return true;
+    if (::abs(theDataKeeper->Index()) > itsMaxLatestDataCount) return true;
     return false;
   }
 
@@ -293,8 +285,7 @@ static boost::shared_ptr<NFmiQueryDataKeeper> FindQDataKeeper(
        it != theQueryDatas.end();
        ++it)
   {
-    if ((*it)->Index() == theIndex)
-      return (*it);
+    if ((*it)->Index() == theIndex) return (*it);
   }
   return boost::shared_ptr<NFmiQueryDataKeeper>();
 }
@@ -309,13 +300,11 @@ static boost::shared_ptr<NFmiQueryDataKeeper> FindQDataKeeper(
 // esimerkin mukaisesti 00 mallipinta data.
 boost::shared_ptr<NFmiQueryDataKeeper> NFmiQueryDataSetKeeper::GetDataKeeper(int theIndex)
 {
-  if (theIndex > 0)
-    theIndex = 0;
+  if (theIndex > 0) theIndex = 0;
 
   boost::shared_ptr<NFmiQueryDataKeeper> qDataKeeperPtr =
       ::FindQDataKeeper(itsQueryDatas, theIndex);
-  if (qDataKeeperPtr)
-    return qDataKeeperPtr;
+  if (qDataKeeperPtr) return qDataKeeperPtr;
 
   if (DoOnDemandOldDataLoad(theIndex))
     return ::FindQDataKeeper(
@@ -424,10 +413,7 @@ void NFmiQueryDataSetKeeper::ReadAllOldDatasInMemory(void)
   }
 }
 
-size_t NFmiQueryDataSetKeeper::DataCount(void)
-{
-  return itsQueryDatas.size();
-}
+size_t NFmiQueryDataSetKeeper::DataCount(void) { return itsQueryDatas.size(); }
 
 size_t NFmiQueryDataSetKeeper::DataByteCount(void)
 {
@@ -443,8 +429,7 @@ bool NFmiQueryDataSetKeeper::CheckKeepTime(ListType::iterator &it)
 {
   if ((*it)->Index() != 0)
   {  // vain viimeisin data jää tutkimatta, koska sitä ei ole tarkoitus poistaa muistista koskaan
-    if ((*it)->LastUsedInMS() > itsKeepInMemoryTime * 60 * 1000)
-      return true;
+    if ((*it)->LastUsedInMS() > itsKeepInMemoryTime * 60 * 1000) return true;
   }
   return false;
 }
@@ -519,8 +504,7 @@ int NFmiQueryDataSetKeeper::GetNearestUnRegularTimeIndex(const NFmiMetTime &theT
 
     if (timeDiffsWithIndexies.size())
     {
-      if (timeDiffsWithIndexies.size() <= 1)
-        return timeDiffsWithIndexies.begin()->second;
+      if (timeDiffsWithIndexies.size() <= 1) return timeDiffsWithIndexies.begin()->second;
 
       std::map<long, int>::iterator it2 = timeDiffsWithIndexies.begin();
       long diffValue1 = it2->first;

--- a/smarttools/NFmiQueryDataKeeper.h
+++ b/smarttools/NFmiQueryDataKeeper.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <newbase/NFmiMilliSecondTimer.h>
-#include <newbase/NFmiDataMatrix.h>
-#include <newbase/NFmiMetTime.h>
-#include <newbase/NFmiInfoData.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiInfoData.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiMilliSecondTimer.h>
 #include <list>
 #include <set>
 
@@ -133,4 +133,3 @@ class NFmiQueryDataSetKeeper
   int itsKeepInMemoryTime;  // kuinka kauan pidetään data muistissa, jos sitä ei ole käytetty.
                             // yksikkö on minuutteja
 };
-

--- a/smarttools/NFmiRawTempStationInfoSystem.cpp
+++ b/smarttools/NFmiRawTempStationInfoSystem.cpp
@@ -3,8 +3,8 @@
 
 #include "NFmiRawTempStationInfoSystem.h"
 #include <newbase/NFmiCommentStripper.h>
-#include <newbase/NFmiStation.h>
 #include <newbase/NFmiLocationBag.h>
+#include <newbase/NFmiStation.h>
 #include <fstream>
 
 using namespace std;
@@ -53,8 +53,7 @@ static bool GetStationFromString(const std::string &theStationStr,
   std::string name;
   for (unsigned int i = 3; i < strVector.size(); i++)
   {
-    if (i != 3)
-      name += " ";
+    if (i != 3) name += " ";
     name += strVector[i];
   }
   theStationOut.SetName(NFmiString(name));
@@ -233,8 +232,7 @@ static double GetLatOrLonFromString(const std::string &theLatOrLonStr,
   double value = degrees;
   value += minutes / 60.;
   value += seconds / 3600.;
-  if (posSign == false)
-    value = -value;
+  if (posSign == false) value = -value;
   return value;
 }
 
@@ -373,16 +371,11 @@ void NFmiSilamStationList::Init(const std::string &theInitFileName)
                              theInitFileName);
 }
 
-void NFmiSilamStationList::Clear(void)
-{
-  itsLocations.clear();
-}
+void NFmiSilamStationList::Clear(void) { itsLocations.clear(); }
 
 // ****************   NFmiWmoStationLookUpSystem  *************************************
 
-NFmiWmoStationLookUpSystem::NFmiWmoStationLookUpSystem(void) : itsStations(), itsInitLogMessage()
-{
-}
+NFmiWmoStationLookUpSystem::NFmiWmoStationLookUpSystem(void) : itsStations(), itsInitLogMessage() {}
 
 const NFmiWmoStation &NFmiWmoStationLookUpSystem::GetStation(long theWmoId)
 {

--- a/smarttools/NFmiRawTempStationInfoSystem.h
+++ b/smarttools/NFmiRawTempStationInfoSystem.h
@@ -23,6 +23,7 @@ class NFmiRawTempStationInfoSystem
   void Init(const std::string &theInitFileName);
   NFmiHPlaceDescriptor &Locations(void) { return itsLocations; }
   const std::string &InitLogMessage(void) const { return itsInitLogMessage; }
+
  private:
   std::string
       itsInitLogMessage;  // onnistuneen initialisoinnin viesti, missä voi olla varoituksia lokiin.
@@ -46,6 +47,7 @@ class NFmiSilamStationList
   void Clear(void);
   checkedVector<NFmiSilamStationList::Station> &Locations(void) { return itsLocations; }
   const std::string &InitLogMessage(void) const { return itsInitLogMessage; }
+
  private:
   std::string
       itsInitLogMessage;  // onnistuneen initialisoinnin viesti, missä voi olla varoituksia lokiin.
@@ -95,4 +97,3 @@ class NFmiWmoStationLookUpSystem
   std::string itsInitLogMessage;  // onnistuneen tai epäonnistuneen initialisoinnin viesti, missä
                                   // voi olla varoituksia lokiin.
 };
-

--- a/smarttools/NFmiSmartInfo.cpp
+++ b/smarttools/NFmiSmartInfo.cpp
@@ -3,9 +3,7 @@
 #include "NFmiModifiableQDatasBookKeeping.h"
 #include <newbase/NFmiQueryData.h>
 
-NFmiSmartInfo::NFmiSmartInfo(void) : NFmiOwnerInfo(), itsQDataBookKeepingPtr()
-{
-}
+NFmiSmartInfo::NFmiSmartInfo(void) : NFmiOwnerInfo(), itsQDataBookKeepingPtr() {}
 
 NFmiSmartInfo::NFmiSmartInfo(NFmiQueryData *theOwnedData,
                              NFmiInfoData::Type theDataType,
@@ -28,9 +26,7 @@ NFmiSmartInfo::NFmiSmartInfo(const NFmiSmartInfo &theInfo)
 {
 }
 
-NFmiSmartInfo::~NFmiSmartInfo(void)
-{
-}
+NFmiSmartInfo::~NFmiSmartInfo(void) {}
 
 NFmiSmartInfo &NFmiSmartInfo::operator=(const NFmiSmartInfo &theInfo)
 {
@@ -67,16 +63,13 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartInfo::CreateShallowCopyOfHighestIn
   if (theInfo)
   {
     NFmiSmartInfo *smartInfo = dynamic_cast<NFmiSmartInfo *>(theInfo.get());
-    if (smartInfo)
-      return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiSmartInfo(*smartInfo));
+    if (smartInfo) return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiSmartInfo(*smartInfo));
 
     NFmiOwnerInfo *ownerInfo = dynamic_cast<NFmiOwnerInfo *>(theInfo.get());
-    if (ownerInfo)
-      return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiOwnerInfo(*ownerInfo));
+    if (ownerInfo) return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiOwnerInfo(*ownerInfo));
 
     NFmiFastQueryInfo *fastInfo = dynamic_cast<NFmiFastQueryInfo *>(theInfo.get());
-    if (fastInfo)
-      return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiFastQueryInfo(*fastInfo));
+    if (fastInfo) return boost::shared_ptr<NFmiFastQueryInfo>(new NFmiFastQueryInfo(*fastInfo));
   }
 
   return boost::shared_ptr<NFmiFastQueryInfo>();
@@ -125,10 +118,7 @@ void NFmiSmartInfo::LocationSelectionUndoLevel(int theNewUndoLevel)
   itsQDataBookKeepingPtr->LocationSelectionUndoLevel(theNewUndoLevel);
 }
 
-bool NFmiSmartInfo::LoadedFromFile(void)
-{
-  return itsQDataBookKeepingPtr->LoadedFromFile();
-}
+bool NFmiSmartInfo::LoadedFromFile(void) { return itsQDataBookKeepingPtr->LoadedFromFile(); }
 
 void NFmiSmartInfo::LoadedFromFile(bool loadedFromFile)
 {
@@ -161,40 +151,25 @@ bool NFmiSmartInfo::SnapShotData(const std::string &theAction,
       theAction, theHarmonizerBookKeepingData, *itsRefRawData);
 }
 
-bool NFmiSmartInfo::Undo(void)
-{
-  return itsQDataBookKeepingPtr->Undo();
-}
+bool NFmiSmartInfo::Undo(void) { return itsQDataBookKeepingPtr->Undo(); }
 
-bool NFmiSmartInfo::Redo(void)
-{
-  return itsQDataBookKeepingPtr->Redo();
-}
+bool NFmiSmartInfo::Redo(void) { return itsQDataBookKeepingPtr->Redo(); }
 
 bool NFmiSmartInfo::UndoData(const NFmiHarmonizerBookKeepingData &theHarmonizerBookKeepingData)
 {
   return itsQDataBookKeepingPtr->UndoData(theHarmonizerBookKeepingData, *itsRefRawData);
 }
 
-bool NFmiSmartInfo::RedoData(void)
-{
-  return itsQDataBookKeepingPtr->RedoData(*itsRefRawData);
-}
+bool NFmiSmartInfo::RedoData(void) { return itsQDataBookKeepingPtr->RedoData(*itsRefRawData); }
 
 const NFmiHarmonizerBookKeepingData *NFmiSmartInfo::CurrentHarmonizerBookKeepingData(void) const
 {
   return itsQDataBookKeepingPtr->CurrentHarmonizerBookKeepingData();
 }
 
-bool NFmiSmartInfo::IsDirty(void) const
-{
-  return itsQDataBookKeepingPtr->IsDirty();
-}
+bool NFmiSmartInfo::IsDirty(void) const { return itsQDataBookKeepingPtr->IsDirty(); }
 
-void NFmiSmartInfo::Dirty(bool newState)
-{
-  itsQDataBookKeepingPtr->Dirty(newState);
-}
+void NFmiSmartInfo::Dirty(bool newState) { itsQDataBookKeepingPtr->Dirty(newState); }
 
 int NFmiSmartInfo::MaskedCount(unsigned long theMaskType,
                                unsigned long theIndex,
@@ -239,7 +214,4 @@ void NFmiSmartInfo::MaskType(unsigned long theMaskType)
   itsQDataBookKeepingPtr->MaskType(theMaskType);
 }
 
-unsigned long NFmiSmartInfo::MaskType(void)
-{
-  return itsQDataBookKeepingPtr->MaskType();
-}
+unsigned long NFmiSmartInfo::MaskType(void) { return itsQDataBookKeepingPtr->MaskType(); }

--- a/smarttools/NFmiSmartToolCalculation.cpp
+++ b/smarttools/NFmiSmartToolCalculation.cpp
@@ -30,12 +30,12 @@
 #include "NFmiSmartToolCalculation.h"
 #include "NFmiAreaMaskInfo.h"
 #include "NFmiCalculationConstantValue.h"
-#include <newbase/NFmiFastQueryInfo.h>
+#include "NFmiDictionaryFunction.h"
 #include <newbase/NFmiDataModifierClasses.h>
+#include <newbase/NFmiFastQueryInfo.h>
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>
-#include "NFmiDictionaryFunction.h"
 
 using namespace std;
 
@@ -84,9 +84,7 @@ NFmiSmartToolCalculation::NFmiSmartToolCalculation(const NFmiSmartToolCalculatio
 {
 }
 
-NFmiSmartToolCalculation::~NFmiSmartToolCalculation(void)
-{
-}
+NFmiSmartToolCalculation::~NFmiSmartToolCalculation(void) {}
 
 //--------------------------------------------------------
 // Calculate
@@ -180,8 +178,7 @@ void NFmiSmartToolCalculation::Calculate_ver2(const NFmiCalculationParams &theCa
 // ei ota huomioon missing arvoa, koska se pitää ottaa huomioon jo ennen tämän kutsua.
 float NFmiSmartToolCalculation::GetInsideLimitsValue(float theValue)
 {
-  if (theValue == kFloatMissing)
-    return theValue;
+  if (theValue == kFloatMissing) return theValue;
 
   if (fDoLimitCheck)
   {
@@ -347,12 +344,10 @@ void NFmiSmartToolCalculation::eval_exp5(double &result,
                                          const NFmiCalculationParams &theCalculationParams)
 {
   NFmiAreaMask::CalculationOperator op = token->GetCalculationOperator();
-  if (op == NFmiAreaMask::Add || op == NFmiAreaMask::Sub)
-    get_token();
+  if (op == NFmiAreaMask::Add || op == NFmiAreaMask::Sub) get_token();
   eval_exp6(result, theCalculationParams);
 
-  if (op == NFmiAreaMask::Sub && result != kFloatMissing)
-    result = -result;
+  if (op == NFmiAreaMask::Sub && result != kFloatMissing) result = -result;
 }
 
 #if 0
@@ -498,8 +493,7 @@ static float GetCurrentHeightStep(float theHeight)
 template <typename T>
 static bool IsEqualEnough(T value1, T value2, T usedEpsilon)
 {
-  if (::fabs(static_cast<double>(value1 - value2)) < usedEpsilon)
-    return true;
+  if (::fabs(static_cast<double>(value1 - value2)) < usedEpsilon) return true;
   return false;
 }
 void NFmiSmartToolCalculation::eval_ThreeArgumentFunctionZ(
@@ -922,12 +916,10 @@ void NFmiSmartToolCalculation::bin_eval_exp5(bool &maskresult,
                                              const NFmiCalculationParams &theCalculationParams)
 {
   NFmiAreaMask::CalculationOperator op = token->GetCalculationOperator();
-  if (op == NFmiAreaMask::Add || op == NFmiAreaMask::Sub)
-    get_token();
+  if (op == NFmiAreaMask::Add || op == NFmiAreaMask::Sub) get_token();
   bin_eval_exp6(maskresult, result, theCalculationParams);
 
-  if (op == NFmiAreaMask::Sub && result != kFloatMissing)
-    result = -result;
+  if (op == NFmiAreaMask::Sub && result != kFloatMissing) result = -result;
 }
 
 void NFmiSmartToolCalculation::CalcThreeArgumentFunction(

--- a/smarttools/NFmiSmartToolCalculation.h
+++ b/smarttools/NFmiSmartToolCalculation.h
@@ -8,11 +8,11 @@
 // Tämä luokka hoitaa yhden laskurivin esim. T = T + 1
 //**********************************************************
 
+#include <boost/shared_ptr.hpp>
 #include <newbase/NFmiAreaMask.h>
-#include <newbase/NFmiPoint.h>
 #include <newbase/NFmiDataMatrix.h>
 #include <newbase/NFmiMetTime.h>
-#include <boost/shared_ptr.hpp>
+#include <newbase/NFmiPoint.h>
 
 class NFmiFastQueryInfo;
 class NFmiDataModifier;
@@ -66,6 +66,7 @@ class NFmiSmartToolCalculation
   void SetLimits(float theLowerLimit, float theUpperLimit, bool theDoLimitCheck);
   bool AllowMissingValueAssignment(void) { return fAllowMissingValueAssignment; };
   void AllowMissingValueAssignment(bool newState) { fAllowMissingValueAssignment = newState; };
+
  private:
   std::string itsCalculationText;  // originaali teksti, mistä tämä lasku on tulkittu
   typedef checkedVector<boost::shared_ptr<NFmiAreaMask> >::iterator CalcIter;

--- a/smarttools/NFmiSmartToolCalculationInfo.cpp
+++ b/smarttools/NFmiSmartToolCalculationInfo.cpp
@@ -18,15 +18,12 @@ NFmiSmartToolCalculationInfo::NFmiSmartToolCalculationInfo(void)
 {
 }
 
-NFmiSmartToolCalculationInfo::~NFmiSmartToolCalculationInfo(void)
-{
-}
+NFmiSmartToolCalculationInfo::~NFmiSmartToolCalculationInfo(void) {}
 
 void NFmiSmartToolCalculationInfo::AddCalculationInfo(
     boost::shared_ptr<NFmiAreaMaskInfo> &theAreaMaskInfo)
 {
-  if (theAreaMaskInfo)
-    itsCalculationOperandInfoVector.push_back(theAreaMaskInfo);
+  if (theAreaMaskInfo) itsCalculationOperandInfoVector.push_back(theAreaMaskInfo);
 }
 
 /*! tarkistaa onko lause muotoa:

--- a/smarttools/NFmiSmartToolCalculationInfo.h
+++ b/smarttools/NFmiSmartToolCalculationInfo.h
@@ -15,8 +15,8 @@
 // operandeja (n kpl) ja operaatioita (n-1 kpl).
 //**********************************************************
 
-#include <newbase/NFmiDataMatrix.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiDataMatrix.h>
 
 class NFmiAreaMaskInfo;
 
@@ -37,6 +37,7 @@ class NFmiSmartToolCalculationInfo
   void SetCalculationText(const std::string& theText) { itsCalculationText = theText; }
   void CheckIfAllowMissingValueAssignment(void);
   bool AllowMissingValueAssignment(void) { return fAllowMissingValueAssignment; };
+
  private:
   // HUOM!! Tämä erillinen ResultInfo-systeemi oli huono ratkaisu, laita ne mielluummin
   // osaksi laskentaketjua (itsCalculationOperandInfoVector:iin).

--- a/smarttools/NFmiSmartToolCalculationSection.cpp
+++ b/smarttools/NFmiSmartToolCalculationSection.cpp
@@ -19,9 +19,7 @@
 //--------------------------------------------------------
 // Constructor/Destructor
 //--------------------------------------------------------
-NFmiSmartToolCalculationSection::NFmiSmartToolCalculationSection(void) : itsCalculations()
-{
-}
+NFmiSmartToolCalculationSection::NFmiSmartToolCalculationSection(void) : itsCalculations() {}
 
 NFmiSmartToolCalculationSection::NFmiSmartToolCalculationSection(
     const NFmiSmartToolCalculationSection &theOther)
@@ -29,9 +27,7 @@ NFmiSmartToolCalculationSection::NFmiSmartToolCalculationSection(
 {
 }
 
-NFmiSmartToolCalculationSection::~NFmiSmartToolCalculationSection(void)
-{
-}
+NFmiSmartToolCalculationSection::~NFmiSmartToolCalculationSection(void) {}
 //--------------------------------------------------------
 // Calculate
 //--------------------------------------------------------
@@ -52,15 +48,13 @@ void NFmiSmartToolCalculationSection::Calculate_ver2(
 void NFmiSmartToolCalculationSection::AddCalculations(
     const boost::shared_ptr<NFmiSmartToolCalculation> &value)
 {
-  if (value)
-    itsCalculations.push_back(value);
+  if (value) itsCalculations.push_back(value);
 }
 
 boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolCalculationSection::FirstVariableInfo(void)
 {
   boost::shared_ptr<NFmiFastQueryInfo> info;
-  if (itsCalculations.size())
-    info = itsCalculations[0]->GetResultInfo();
+  if (itsCalculations.size()) info = itsCalculations[0]->GetResultInfo();
   return info;
 }
 

--- a/smarttools/NFmiSmartToolCalculationSection.h
+++ b/smarttools/NFmiSmartToolCalculationSection.h
@@ -11,9 +11,9 @@
 // P = P + 2
 //**********************************************************
 
-#include <newbase/NFmiDataMatrix.h>
-#include <newbase/NFmiAreaMask.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiAreaMask.h>
+#include <newbase/NFmiDataMatrix.h>
 
 class NFmiPoint;
 class NFmiMetTime;

--- a/smarttools/NFmiSmartToolCalculationSectionInfo.cpp
+++ b/smarttools/NFmiSmartToolCalculationSectionInfo.cpp
@@ -14,18 +14,13 @@
 //--------------------------------------------------------
 // Constructor/Destructor
 //--------------------------------------------------------
-NFmiSmartToolCalculationSectionInfo::NFmiSmartToolCalculationSectionInfo(void)
-{
-}
-NFmiSmartToolCalculationSectionInfo::~NFmiSmartToolCalculationSectionInfo(void)
-{
-}
+NFmiSmartToolCalculationSectionInfo::NFmiSmartToolCalculationSectionInfo(void) {}
+NFmiSmartToolCalculationSectionInfo::~NFmiSmartToolCalculationSectionInfo(void) {}
 
 void NFmiSmartToolCalculationSectionInfo::AddCalculationInfo(
     boost::shared_ptr<NFmiSmartToolCalculationInfo> &value)
 {
-  if (value)
-    itsSmartToolCalculationInfoVector.push_back(value);
+  if (value) itsSmartToolCalculationInfoVector.push_back(value);
 }
 
 // Lisätään set:iin kaikki parametrit, joita tässä sectioniossa voidaan muokata.

--- a/smarttools/NFmiSmartToolCalculationSectionInfo.h
+++ b/smarttools/NFmiSmartToolCalculationSectionInfo.h
@@ -13,8 +13,8 @@
 // Yksi rivi on aina yksi lasku ja laskussa pitää olla sijoitus johonkin parametriin (=).
 //**********************************************************
 
-#include <newbase/NFmiDataMatrix.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiDataMatrix.h>
 #include <set>
 
 class NFmiSmartToolCalculationInfo;

--- a/smarttools/NFmiSmartToolInfo.cpp
+++ b/smarttools/NFmiSmartToolInfo.cpp
@@ -5,12 +5,12 @@
  */
 
 #include "NFmiSmartToolInfo.h"
+#include <boost/filesystem.hpp>
 #include <newbase/NFmiFileString.h>
 #include <newbase/NFmiFileSystem.h>
 #include <newbase/NFmiSettings.h>
 #include <fstream>
 #include <iterator>
-#include <boost/filesystem.hpp>
 
 using namespace std;
 
@@ -27,9 +27,7 @@ NFmiSmartToolInfo::NFmiSmartToolInfo(void)
 {
 }
 
-NFmiSmartToolInfo::~NFmiSmartToolInfo(void)
-{
-}
+NFmiSmartToolInfo::~NFmiSmartToolInfo(void) {}
 // luetaan  asetukset nykyään NFmiSetting-luokasta
 bool NFmiSmartToolInfo::Init(const std::string &theLoadDirectory)
 {
@@ -151,8 +149,7 @@ bool NFmiSmartToolInfo::ScriptExist(const std::string &theScriptName)
 {
   checkedVector<string> names = GetScriptNames();
   checkedVector<string>::iterator it = std::find(names.begin(), names.end(), theScriptName);
-  if (it != names.end())
-    return true;
+  if (it != names.end()) return true;
   return false;
 }
 checkedVector<std::string> NFmiSmartToolInfo::GetScriptNames(void)
@@ -166,11 +163,9 @@ checkedVector<std::string> NFmiSmartToolInfo::GetScriptNames(void)
   for (; itDir != itEndDir; ++itDir)
   {
     // "this"-hakemistoa ei laiteta
-    if (*itDir == ".")
-      continue;
+    if (*itDir == ".") continue;
     // jos ollaan ns. root hakemistossa, ei up-hakemistoa laiteta
-    if (itsLoadDirectory == itsRootLoadDirectory && *itDir == "..")
-      continue;
+    if (itsLoadDirectory == itsRootLoadDirectory && *itDir == "..") continue;
     std::string name("<");
     name += *itDir;
     name += ">";
@@ -214,8 +209,7 @@ void NFmiSmartToolInfo::LoadDirectory(const std::string &newValue, bool fSaveSet
   else if (itsLoadDirectory[itsLoadDirectory.size() - 1] != '\\')
     itsLoadDirectory += "\\";
   itsRootLoadDirectory = itsLoadDirectory;
-  if (fSaveSettings)
-    SaveSettings();
+  if (fSaveSettings) SaveSettings();
 }
 
 /*
@@ -242,8 +236,7 @@ static void RemoveLastPartOfDirectory(string &thePath)
   else if (pos2 != string::npos)
     usedPos = pos2;
 
-  if (usedPos != string::npos)
-    thePath = string(thePath.begin(), thePath.begin() + usedPos + 1);
+  if (usedPos != string::npos) thePath = string(thePath.begin(), thePath.begin() + usedPos + 1);
 }
 
 void NFmiSmartToolInfo::SetCurrentLoadDirectory(const std::string &newValue)

--- a/smarttools/NFmiSmartToolIntepreter.cpp
+++ b/smarttools/NFmiSmartToolIntepreter.cpp
@@ -11,18 +11,18 @@
 
 #include "NFmiSmartToolIntepreter.h"
 #include "NFmiAreaMaskInfo.h"
-#include "NFmiSmartToolCalculationSectionInfo.h"
 #include "NFmiAreaMaskSectionInfo.h"
-#include "NFmiSmartToolCalculationInfo.h"
 #include "NFmiDictionaryFunction.h"
-#include "NFmiProducerSystem.h"
 #include "NFmiExtraMacroParamData.h"
+#include "NFmiProducerSystem.h"
+#include "NFmiSmartToolCalculationInfo.h"
+#include "NFmiSmartToolCalculationSectionInfo.h"
 
+#include <newbase/NFmiEnumConverter.h>
+#include <newbase/NFmiLevel.h>
+#include <newbase/NFmiLevelType.h>
 #include <newbase/NFmiPreProcessor.h>
 #include <newbase/NFmiValueString.h>
-#include <newbase/NFmiLevelType.h>
-#include <newbase/NFmiLevel.h>
-#include <newbase/NFmiEnumConverter.h>
 
 #include <algorithm>
 #include <cctype>
@@ -53,13 +53,8 @@ NFmiSmartToolCalculationBlockInfoVector::NFmiSmartToolCalculationBlockInfoVector
 {
 }
 
-NFmiSmartToolCalculationBlockInfoVector::~NFmiSmartToolCalculationBlockInfoVector(void)
-{
-}
-void NFmiSmartToolCalculationBlockInfoVector::Clear(void)
-{
-  itsCalculationBlockInfos.clear();
-}
+NFmiSmartToolCalculationBlockInfoVector::~NFmiSmartToolCalculationBlockInfoVector(void) {}
+void NFmiSmartToolCalculationBlockInfoVector::Clear(void) { itsCalculationBlockInfos.clear(); }
 // Ottaa pointterin 'omistukseensa' eli pitää luoda ulkona new:llä ja antaa tänne
 void NFmiSmartToolCalculationBlockInfoVector::Add(
     boost::shared_ptr<NFmiSmartToolCalculationBlockInfo> &theBlockInfo)
@@ -89,18 +84,13 @@ NFmiSmartToolCalculationBlockInfo::NFmiSmartToolCalculationBlockInfo(void)
 {
 }
 
-NFmiSmartToolCalculationBlockInfo::~NFmiSmartToolCalculationBlockInfo(void)
-{
-}
+NFmiSmartToolCalculationBlockInfo::~NFmiSmartToolCalculationBlockInfo(void) {}
 
 void NFmiSmartToolCalculationBlockInfo::Clear(void)
 {
-  if (itsIfCalculationBlockInfos)
-    itsIfCalculationBlockInfos->Clear();
-  if (itsElseIfCalculationBlockInfos)
-    itsElseIfCalculationBlockInfos->Clear();
-  if (itsElseCalculationBlockInfos)
-    itsElseCalculationBlockInfos->Clear();
+  if (itsIfCalculationBlockInfos) itsIfCalculationBlockInfos->Clear();
+  if (itsElseIfCalculationBlockInfos) itsElseIfCalculationBlockInfos->Clear();
+  if (itsElseCalculationBlockInfos) itsElseCalculationBlockInfos->Clear();
   fElseSectionExist = false;
 }
 
@@ -167,10 +157,7 @@ NFmiSmartToolIntepreter::NFmiSmartToolIntepreter(NFmiProducerSystem *theProducer
 {
   NFmiSmartToolIntepreter::InitTokens(itsProducerSystem, theObservationProducerSystem);
 }
-NFmiSmartToolIntepreter::~NFmiSmartToolIntepreter(void)
-{
-  Clear();
-}
+NFmiSmartToolIntepreter::~NFmiSmartToolIntepreter(void) { Clear(); }
 //--------------------------------------------------------
 // Interpret
 //--------------------------------------------------------
@@ -207,8 +194,7 @@ void NFmiSmartToolIntepreter::Interpret(const std::string &theMacroText,
     NFmiSmartToolCalculationBlockInfo block;
     try
     {
-      if (index > 500)
-        throw runtime_error(::GetDictionaryString("SmartToolErrorTooManyBlocks"));
+      if (index > 500) throw runtime_error(::GetDictionaryString("SmartToolErrorTooManyBlocks"));
       fGoOn = CheckoutPossibleNextCalculationBlock(block, true);
       itsSmartToolCalculationBlocks.push_back(block);
       if (itsCheckOutTextStartPosition != itsStrippedMacroText.end() &&
@@ -330,8 +316,7 @@ bool NFmiSmartToolIntepreter::CheckoutPossibleNextCalculationBlock(
       CheckoutPossibleNextCalculationSection(theBlock.itsLastCalculationSectionInfo,
                                              fWasBlockMarksFound);
   }
-  if (itsCheckOutTextStartPosition == itsStrippedMacroText.end())
-    return false;
+  if (itsCheckOutTextStartPosition == itsStrippedMacroText.end()) return false;
   return true;
 }
 
@@ -346,14 +331,12 @@ void NFmiSmartToolIntepreter::InitCheckOut(void)
 static std::string::iterator EatWhiteSpaces(std::string::iterator &it,
                                             const std::string::const_iterator &endIter)
 {
-  if (it == endIter)
-    return it;
+  if (it == endIter) return it;
 
   while (std::isspace(*it))
   {
     ++it;
-    if (it == endIter)
-      break;
+    if (it == endIter) break;
   };
   return it;
 }
@@ -410,12 +393,10 @@ bool NFmiSmartToolIntepreter::ExtractPossibleNextCalculationSection(bool &fWasBl
 
       nextLine = string(itsCheckOutTextStartPosition, eolPos);
       nextLine += '\n';
-      if (eolPos != itsStrippedMacroText.end() && (*eolPos == '\n' || *eolPos == '\r'))
-        ++eolPos;
+      if (eolPos != itsStrippedMacroText.end() && (*eolPos == '\n' || *eolPos == '\r')) ++eolPos;
     } while (IsPossibleCalculationLine(nextLine));
   }
-  if (itsCheckOutSectionText.empty())
-    return false;
+  if (itsCheckOutSectionText.empty()) return false;
   return true;
 }
 
@@ -424,10 +405,8 @@ bool NFmiSmartToolIntepreter::ExtractPossibleNextCalculationSection(bool &fWasBl
 // 2. Pitää olla sijoitus-operaatio eli '='
 bool NFmiSmartToolIntepreter::IsPossibleCalculationLine(const std::string &theTextLine)
 {
-  if (FindAnyFromText(theTextLine, itsTokenConditionalCommands))
-    return false;
-  if (theTextLine.find(string("=")) != string::npos)
-    return true;
+  if (FindAnyFromText(theTextLine, itsTokenConditionalCommands)) return false;
+  if (theTextLine.find(string("=")) != string::npos) return true;
 
   if (std::find_if(theTextLine.begin(), theTextLine.end(), std::not1(std::ptr_fun(::isspace))) !=
       theTextLine.end())
@@ -442,12 +421,9 @@ bool NFmiSmartToolIntepreter::IsPossibleCalculationLine(const std::string &theTe
 // 3. Pitää olla ensin '('- ja sitten ')' -merkit
 bool NFmiSmartToolIntepreter::IsPossibleIfConditionLine(const std::string &theTextLine)
 {
-  if (!FindAnyFromText(theTextLine, itsTokenIfCommands))
-    return false;
-  if (FindAnyFromText(theTextLine, itsTokenElseIfCommands))
-    return false;
-  if (FindAnyFromText(theTextLine, itsTokenElseCommands))
-    return false;
+  if (!FindAnyFromText(theTextLine, itsTokenIfCommands)) return false;
+  if (FindAnyFromText(theTextLine, itsTokenElseIfCommands)) return false;
+  if (FindAnyFromText(theTextLine, itsTokenElseCommands)) return false;
   if ((theTextLine.find(string("(")) != string::npos) &&
       (theTextLine.find(string(")")) != string::npos))
     return true;
@@ -460,8 +436,7 @@ bool NFmiSmartToolIntepreter::IsPossibleIfConditionLine(const std::string &theTe
 // 3. Pitää olla ensin '('- ja sitten ')' -merkit
 bool NFmiSmartToolIntepreter::IsPossibleElseIfConditionLine(const std::string &theTextLine)
 {
-  if (!FindAnyFromText(theTextLine, itsTokenElseIfCommands))
-    return false;
+  if (!FindAnyFromText(theTextLine, itsTokenElseIfCommands)) return false;
   if ((theTextLine.find(string("(")) != string::npos) &&
       (theTextLine.find(string(")")) != string::npos))
     return true;
@@ -475,8 +450,7 @@ bool NFmiSmartToolIntepreter::IsPossibleElseConditionLine(const std::string &the
   stringstream sstream(theTextLine);
   string tmp;
   sstream >> tmp;
-  if (!FindAnyFromText(tmp, itsTokenElseCommands))
-    return false;
+  if (!FindAnyFromText(tmp, itsTokenElseCommands)) return false;
   tmp = "";  // nollataan tämä, koska MSVC++7.1 ei sijoita jostain syystä mitään kun ollaan tultu
              // loppuun (muilla kääntäjillä on sijoitettu tyhjä tmp-stringiin)
   sstream >> tmp;
@@ -489,8 +463,7 @@ bool NFmiSmartToolIntepreter::IsPossibleElseConditionLine(const std::string &the
 
 static bool IsWordContinuing(char ch)
 {
-  if (isalnum(ch) || ch == '_')
-    return true;
+  if (isalnum(ch) || ch == '_') return true;
   return false;
 }
 
@@ -508,14 +481,12 @@ bool NFmiSmartToolIntepreter::FindAnyFromText(const std::string &theText,
       if (pos > 0)
       {
         char ch1 = theText[pos - 1];
-        if (IsWordContinuing(ch1))
-          continue;
+        if (IsWordContinuing(ch1)) continue;
       }
       if (pos + theSearchedItems[i].size() < theText.size())
       {
         char ch2 = theText[pos + theSearchedItems[i].size()];
-        if (IsWordContinuing(ch2))
-          continue;
+        if (IsWordContinuing(ch2)) continue;
       }
       return true;
     }
@@ -743,8 +714,7 @@ bool NFmiSmartToolIntepreter::InterpretMasks(
   }
 
   // minimissään erilaisia lasku elementtejä pitää olla vahintäin 3 (esim. T > 15)
-  if (theAreaMaskSectionInfo->GetAreaMaskInfoVector().size() >= 3)
-    return true;
+  if (theAreaMaskSectionInfo->GetAreaMaskInfoVector().size() >= 3) return true;
   throw runtime_error(::GetDictionaryString("SmartToolErrorConditionalWasNotComplete") + ":\n" +
                       theMaskSectionText);
 }
@@ -778,8 +748,7 @@ bool NFmiSmartToolIntepreter::InterpretCalculationSection(
       {
         boost::shared_ptr<NFmiSmartToolCalculationInfo> calculationInfo =
             InterpretCalculationLine(nextLine);
-        if (calculationInfo)
-          theSectionInfo->AddCalculationInfo(calculationInfo);
+        if (calculationInfo) theSectionInfo->AddCalculationInfo(calculationInfo);
       }
     }
     catch (ExtraInfoMacroLineException &)
@@ -796,8 +765,7 @@ bool NFmiSmartToolIntepreter::InterpretCalculationSection(
 bool NFmiSmartToolIntepreter::ConsistOnlyWhiteSpaces(const std::string &theText)
 {
   static const string someSpaces(" \t\r\n");
-  if (theText.find_first_not_of(someSpaces) == string::npos)
-    return true;
+  if (theText.find_first_not_of(someSpaces) == string::npos) return true;
   return false;
 }
 
@@ -898,13 +866,11 @@ bool NFmiSmartToolIntepreter::GetToken(void)
   temp = token;
   *temp = '\0';
 
-  if (exp_ptr >= exp_end)
-    return false;  // at end of expression
+  if (exp_ptr >= exp_end) return false;  // at end of expression
 
   while (exp_ptr < exp_end && std::isspace(*exp_ptr))
-    ++exp_ptr;  // skip over white space
-  if (exp_ptr >= exp_end)
-    return false;  // at end of expression
+    ++exp_ptr;                           // skip over white space
+  if (exp_ptr >= exp_end) return false;  // at end of expression
 
   // HUOM! tässä delimiter rimpsussa ei ole spacea, joten ei voi tehdä yhteistä stringiä, muista
   // päivittää myös IsDelim-metodi
@@ -936,8 +902,7 @@ bool NFmiSmartToolIntepreter::GetToken(void)
     while (!IsDelim(*exp_ptr))
     {
       *temp++ = *exp_ptr++;
-      if (exp_ptr >= exp_end)
-        break;              // at end of expression
+      if (exp_ptr >= exp_end) break;  // at end of expression
       if (*exp_ptr == '[')  // Ollaan tultu kohtaan missa annetaan malliajo eli esim. T_HIR[-1], nyt
                             // jatketaan kunnes löytyy lopetus merkki eli ']'
       {
@@ -953,8 +918,7 @@ bool NFmiSmartToolIntepreter::GetToken(void)
     while (!IsDelim(*exp_ptr))
     {
       *temp++ = *exp_ptr++;
-      if (exp_ptr >= exp_end)
-        break;  // at end of expression
+      if (exp_ptr >= exp_end) break;  // at end of expression
     }
     tok_type = NUMBER;
   }
@@ -980,14 +944,12 @@ void NFmiSmartToolIntepreter::SearchUntil(std::string::iterator &theExp_ptr,
 {
   while (*theExp_ptr != theSearchedCh)
   {
-    if (theExp_ptr >= exp_end)
-      break;  // at end of expression
+    if (theExp_ptr >= exp_end) break;  // at end of expression
     *theTempCharPtr++ = *theExp_ptr++;
   }
   if (*theExp_ptr == theSearchedCh)
   {
-    if (theExp_ptr != exp_end)
-      *theTempCharPtr++ = *theExp_ptr++;
+    if (theExp_ptr != exp_end) *theTempCharPtr++ = *theExp_ptr++;
     *theTempCharPtr = 0;
   }
   else
@@ -1122,8 +1084,7 @@ void NFmiSmartToolIntepreter::InterpretVariable(const std::string &theVariableTe
 
   // tutkitaan ensin onko mahdollisesti variable-muuttuja, jolloin voimme sallia _-merkin käytön
   // muuttujissa
-  if (InterpretPossibleScriptVariable(theVariableText, theMaskInfo, fNewScriptVariable))
-    return;
+  if (InterpretPossibleScriptVariable(theVariableText, theMaskInfo, fNewScriptVariable)) return;
 
   CheckVariableString(theVariableText,
                       paramNameOnly,
@@ -1283,26 +1244,19 @@ bool NFmiSmartToolIntepreter::InterpretVariableCheckTokens(
                               theModelRunIndex))
     return true;
 
-  if (IsVariableConstantValue(theVariableText, theMaskInfo))
-    return true;
+  if (IsVariableConstantValue(theVariableText, theMaskInfo)) return true;
 
-  if (IsVariableThreeArgumentFunction(theVariableText, theMaskInfo))
-    return true;
+  if (IsVariableThreeArgumentFunction(theVariableText, theMaskInfo)) return true;
 
-  if (IsVariableFunction(theVariableText, theMaskInfo))
-    return true;
+  if (IsVariableFunction(theVariableText, theMaskInfo)) return true;
 
-  if (IsVariableMathFunction(theVariableText, theMaskInfo))
-    return true;
+  if (IsVariableMathFunction(theVariableText, theMaskInfo)) return true;
 
-  if (IsVariableRampFunction(theVariableText, theMaskInfo))
-    return true;
+  if (IsVariableRampFunction(theVariableText, theMaskInfo)) return true;
 
-  if (IsVariableMacroParam(theVariableText, theMaskInfo))
-    return true;
+  if (IsVariableMacroParam(theVariableText, theMaskInfo)) return true;
 
-  if (IsVariableDeltaZ(theVariableText, theMaskInfo))
-    return true;
+  if (IsVariableDeltaZ(theVariableText, theMaskInfo)) return true;
 
   if (IsVariableBinaryOperator(theVariableText,
                                theMaskInfo))  // tämä on and ja or tapausten käsittelyyn
@@ -1315,8 +1269,7 @@ bool NFmiSmartToolIntepreter::IsProducerOrig(std::string &theProducerText)
   // Normalize the type name
   string name(theProducerText);
   transform(name.begin(), name.end(), name.begin(), ::tolower);
-  if (name == "orig")
-    return true;
+  if (name == "orig") return true;
   return false;
 }
 
@@ -1498,8 +1451,7 @@ bool NFmiSmartToolIntepreter::IsInMap(mapType &theMap, const std::string &theSea
   std::string lowerCaseItem(theSearchedItem);
   NFmiStringTools::LowerCase(lowerCaseItem);
   typename mapType::iterator it = theMap.find(lowerCaseItem);
-  if (it != theMap.end())
-    return true;
+  if (it != theMap.end()) return true;
   return false;
 }
 
@@ -1764,8 +1716,7 @@ bool NFmiSmartToolIntepreter::IsWantedStart(const std::string &theText,
 {
   string name(theText.substr(0, theWantedStart.size()));
   transform(name.begin(), name.end(), name.begin(), ::tolower);
-  if (name == theWantedStart)
-    return true;
+  if (name == theWantedStart) return true;
   return false;
 }
 
@@ -1776,8 +1727,7 @@ bool NFmiSmartToolIntepreter::IsCaseInsensitiveEqual(const std::string &theStr1,
   transform(tmp1.begin(), tmp1.end(), tmp1.begin(), ::tolower);
   string tmp2(theStr2);
   transform(tmp2.begin(), tmp2.end(), tmp2.begin(), ::tolower);
-  if (tmp1 == tmp2)
-    return true;
+  if (tmp1 == tmp2) return true;
   return false;
 }
 
@@ -1979,14 +1929,10 @@ bool NFmiSmartToolIntepreter::IsVariableFunction(const std::string &theVariableT
                                                  boost::shared_ptr<NFmiAreaMaskInfo> &theMaskInfo)
 {
   // katsotaan onko jokin peek-funktioista
-  if (IsVariablePeekFunction(theVariableText, theMaskInfo))
-    return true;
-  if (IsVariableMetFunction(theVariableText, theMaskInfo))
-    return true;
-  if (IsVariableVertFunction(theVariableText, theMaskInfo))
-    return true;
-  if (IsVariableExtraInfoCommand(theVariableText))
-    throw ExtraInfoMacroLineException();
+  if (IsVariablePeekFunction(theVariableText, theMaskInfo)) return true;
+  if (IsVariableMetFunction(theVariableText, theMaskInfo)) return true;
+  if (IsVariableVertFunction(theVariableText, theMaskInfo)) return true;
+  if (IsVariableExtraInfoCommand(theVariableText)) throw ExtraInfoMacroLineException();
 
   // sitten katsotaan onko jokin integraatio funktioista
   std::string tmp(theVariableText);
@@ -2416,8 +2362,7 @@ std::string NFmiSmartToolIntepreter::HandlePossibleUnaryMarkers(const std::strin
     GetToken();
     returnStr += token;  // lisätään '-'-etumerkki ja seuraava token ja katsotaan mitä syntyy
   }
-  if (returnStr == string("+"))
-    GetToken();  // +-merkki ohitetaan merkityksettömänä
+  if (returnStr == string("+")) GetToken();  // +-merkki ohitetaan merkityksettömänä
   return returnStr;
 }
 
@@ -2566,187 +2511,304 @@ void NFmiSmartToolIntepreter::InitProducerTokens(NFmiProducerSystem *theProducer
 // Just before namespace ModelClimatology starts.
 static void InitEraInterimParams(NFmiSmartToolIntepreter::ParamMap &paramMap)
 {
-    // Cape
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef100"), kFmiCAPEF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef99"), kFmiCAPEF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef975"), kFmiCAPEF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef95"), kFmiCAPEF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef875"), kFmiCAPEF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef50"), kFmiCAPEF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef125"), kFmiCAPEF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef5"), kFmiCAPEF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef025"), kFmiCAPEF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef1"), kFmiCAPEF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef0"), kFmiCAPEF0));
+  // Cape
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef100"), kFmiCAPEF100));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef99"), kFmiCAPEF99));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef975"), kFmiCAPEF97_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef95"), kFmiCAPEF95));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef875"), kFmiCAPEF87_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef50"), kFmiCAPEF50));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef125"), kFmiCAPEF12_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef5"), kFmiCAPEF5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef025"), kFmiCAPEF2_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef1"), kFmiCAPEF1));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("capef0"), kFmiCAPEF0));
 
-    // Td (Dew point)
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf100"), kFmiDewPointF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf99"), kFmiDewPointF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf975"), kFmiDewPointF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf95"), kFmiDewPointF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf875"), kFmiDewPointF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf50"), kFmiDewPointF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf125"), kFmiDewPointF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf5"), kFmiDewPointF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf025"), kFmiDewPointF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf1"), kFmiDewPointF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf0"), kFmiDewPointF0));
+  // Td (Dew point)
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf100"), kFmiDewPointF100));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf99"), kFmiDewPointF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf975"), kFmiDewPointF97_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf95"), kFmiDewPointF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf875"), kFmiDewPointF87_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf50"), kFmiDewPointF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf125"), kFmiDewPointF12_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf5"), kFmiDewPointF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf025"), kFmiDewPointF2_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf1"), kFmiDewPointF1));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tdf0"), kFmiDewPointF0));
 
-    // Ice cover
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf100"), kFmiIceCoverF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf99"), kFmiIceCoverF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf975"), kFmiIceCoverF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf95"), kFmiIceCoverF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf875"), kFmiIceCoverF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf50"), kFmiIceCoverF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf125"), kFmiIceCoverF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf5"), kFmiIceCoverF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf025"), kFmiIceCoverF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf1"), kFmiIceCoverF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf0"), kFmiIceCoverF0));
+  // Ice cover
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf100"), kFmiIceCoverF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf99"), kFmiIceCoverF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf975"), kFmiIceCoverF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf95"), kFmiIceCoverF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf875"), kFmiIceCoverF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf50"), kFmiIceCoverF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf125"), kFmiIceCoverF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf5"), kFmiIceCoverF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf025"), kFmiIceCoverF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf1"), kFmiIceCoverF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("icecoverf0"), kFmiIceCoverF0));
 
-    // Maximum temperature
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf100"), kFmiMaximumTemperatureF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf99"), kFmiMaximumTemperatureF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf975"), kFmiMaximumTemperatureF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf95"), kFmiMaximumTemperatureF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf875"), kFmiMaximumTemperatureF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf50"), kFmiMaximumTemperatureF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf125"), kFmiMaximumTemperatureF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf5"), kFmiMaximumTemperatureF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf025"), kFmiMaximumTemperatureF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf1"), kFmiMaximumTemperatureF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf0"), kFmiMaximumTemperatureF0));
+  // Maximum temperature
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf100"),
+                                                                kFmiMaximumTemperatureF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf99"), kFmiMaximumTemperatureF99));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf975"),
+                                                                kFmiMaximumTemperatureF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf95"), kFmiMaximumTemperatureF95));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf875"),
+                                                                kFmiMaximumTemperatureF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf50"), kFmiMaximumTemperatureF50));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf125"),
+                                                                kFmiMaximumTemperatureF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf5"), kFmiMaximumTemperatureF5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf025"),
+                                                                kFmiMaximumTemperatureF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf1"), kFmiMaximumTemperatureF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tmaxf0"), kFmiMaximumTemperatureF0));
 
-    // Minimum temperature
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf100"), kFmiMinimumTemperatureF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf99"), kFmiMinimumTemperatureF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf975"), kFmiMinimumTemperatureF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf95"), kFmiMinimumTemperatureF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf875"), kFmiMinimumTemperatureF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf50"), kFmiMinimumTemperatureF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf125"), kFmiMinimumTemperatureF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf5"), kFmiMinimumTemperatureF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf025"), kFmiMinimumTemperatureF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf1"), kFmiMinimumTemperatureF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf0"), kFmiMinimumTemperatureF0));
+  // Minimum temperature
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf100"),
+                                                                kFmiMinimumTemperatureF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf99"), kFmiMinimumTemperatureF99));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf975"),
+                                                                kFmiMinimumTemperatureF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf95"), kFmiMinimumTemperatureF95));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf875"),
+                                                                kFmiMinimumTemperatureF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf50"), kFmiMinimumTemperatureF50));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf125"),
+                                                                kFmiMinimumTemperatureF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf5"), kFmiMinimumTemperatureF5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf025"),
+                                                                kFmiMinimumTemperatureF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf1"), kFmiMinimumTemperatureF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tminf0"), kFmiMinimumTemperatureF0));
 
-    // Precipitation 3h
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf100"), kFmiPrecipitation3hF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf99"), kFmiPrecipitation3hF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf975"), kFmiPrecipitation3hF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf95"), kFmiPrecipitation3hF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf875"), kFmiPrecipitation3hF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf50"), kFmiPrecipitation3hF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf125"), kFmiPrecipitation3hF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf5"), kFmiPrecipitation3hF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf025"), kFmiPrecipitation3hF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf1"), kFmiPrecipitation3hF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf0"), kFmiPrecipitation3hF0));
+  // Precipitation 3h
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf100"), kFmiPrecipitation3hF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf99"), kFmiPrecipitation3hF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf975"), kFmiPrecipitation3hF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf95"), kFmiPrecipitation3hF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf875"), kFmiPrecipitation3hF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf50"), kFmiPrecipitation3hF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf125"), kFmiPrecipitation3hF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf5"), kFmiPrecipitation3hF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf025"), kFmiPrecipitation3hF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf1"), kFmiPrecipitation3hF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("rr3hf0"), kFmiPrecipitation3hF0));
 
-    // Pressure
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf100"), kFmiPressureF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf99"), kFmiPressureF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf975"), kFmiPressureF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf95"), kFmiPressureF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf875"), kFmiPressureF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf50"), kFmiPressureF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf125"), kFmiPressureF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf5"), kFmiPressureF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf025"), kFmiPressureF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf1"), kFmiPressureF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf0"), kFmiPressureF0));
+  // Pressure
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf100"), kFmiPressureF100));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf99"), kFmiPressureF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("pf975"), kFmiPressureF97_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf95"), kFmiPressureF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("pf875"), kFmiPressureF87_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf50"), kFmiPressureF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("pf125"), kFmiPressureF12_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf5"), kFmiPressureF5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf025"), kFmiPressureF2_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf1"), kFmiPressureF1));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("pf0"), kFmiPressureF0));
 
-    // Snow depth
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf100"), kFmiSnowDepthF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf99"), kFmiSnowDepthF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf975"), kFmiSnowDepthF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf95"), kFmiSnowDepthF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf875"), kFmiSnowDepthF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf50"), kFmiSnowDepthF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf125"), kFmiSnowDepthF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf5"), kFmiSnowDepthF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf025"), kFmiSnowDepthF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf1"), kFmiSnowDepthF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf0"), kFmiSnowDepthF0));
+  // Snow depth
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf100"), kFmiSnowDepthF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf99"), kFmiSnowDepthF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf975"), kFmiSnowDepthF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf95"), kFmiSnowDepthF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf875"), kFmiSnowDepthF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf50"), kFmiSnowDepthF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf125"), kFmiSnowDepthF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf5"), kFmiSnowDepthF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf025"), kFmiSnowDepthF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf1"), kFmiSnowDepthF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("snowdepthf0"), kFmiSnowDepthF0));
 
-    // Temperature
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf100"), kFmiTemperatureF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf99"), kFmiTemperatureF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf975"), kFmiTemperatureF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf95"), kFmiTemperatureF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf875"), kFmiTemperatureF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf50"), kFmiTemperatureF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf125"), kFmiTemperatureF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf5"), kFmiTemperatureF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf025"), kFmiTemperatureF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf1"), kFmiTemperatureF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf0"), kFmiTemperatureF0));
+  // Temperature
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf100"), kFmiTemperatureF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf99"), kFmiTemperatureF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf975"), kFmiTemperatureF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf95"), kFmiTemperatureF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf875"), kFmiTemperatureF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf50"), kFmiTemperatureF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf125"), kFmiTemperatureF12_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf5"), kFmiTemperatureF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tf025"), kFmiTemperatureF2_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf1"), kFmiTemperatureF1));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tf0"), kFmiTemperatureF0));
 
-    // Temperature sea
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf100"), kFmiTemperatureSeaF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf99"), kFmiTemperatureSeaF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf975"), kFmiTemperatureSeaF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf95"), kFmiTemperatureSeaF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf875"), kFmiTemperatureSeaF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf50"), kFmiTemperatureSeaF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf125"), kFmiTemperatureSeaF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf5"), kFmiTemperatureSeaF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf025"), kFmiTemperatureSeaF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf1"), kFmiTemperatureSeaF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf0"), kFmiTemperatureSeaF0));
+  // Temperature sea
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf100"), kFmiTemperatureSeaF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf99"), kFmiTemperatureSeaF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf975"), kFmiTemperatureSeaF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf95"), kFmiTemperatureSeaF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf875"), kFmiTemperatureSeaF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf50"), kFmiTemperatureSeaF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf125"), kFmiTemperatureSeaF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf5"), kFmiTemperatureSeaF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf025"), kFmiTemperatureSeaF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf1"), kFmiTemperatureSeaF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tseaf0"), kFmiTemperatureSeaF0));
 
-    // Total cloud cover (N)
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf100"), kFmiTotalCloudCoverF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf99"), kFmiTotalCloudCoverF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf975"), kFmiTotalCloudCoverF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf95"), kFmiTotalCloudCoverF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf875"), kFmiTotalCloudCoverF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf50"), kFmiTotalCloudCoverF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf125"), kFmiTotalCloudCoverF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf5"), kFmiTotalCloudCoverF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf025"), kFmiTotalCloudCoverF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf1"), kFmiTotalCloudCoverF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("nf0"), kFmiTotalCloudCoverF0));
+  // Total cloud cover (N)
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf100"), kFmiTotalCloudCoverF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf99"), kFmiTotalCloudCoverF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf975"), kFmiTotalCloudCoverF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf95"), kFmiTotalCloudCoverF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf875"), kFmiTotalCloudCoverF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf50"), kFmiTotalCloudCoverF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf125"), kFmiTotalCloudCoverF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf5"), kFmiTotalCloudCoverF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf025"), kFmiTotalCloudCoverF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf1"), kFmiTotalCloudCoverF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("nf0"), kFmiTotalCloudCoverF0));
 
-    // Total Column Water (TCW)
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf100"), kFmiTotalColumnWaterF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf99"), kFmiTotalColumnWaterF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf975"), kFmiTotalColumnWaterF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf95"), kFmiTotalColumnWaterF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf875"), kFmiTotalColumnWaterF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf50"), kFmiTotalColumnWaterF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf125"), kFmiTotalColumnWaterF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf5"), kFmiTotalColumnWaterF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf025"), kFmiTotalColumnWaterF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf1"), kFmiTotalColumnWaterF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf0"), kFmiTotalColumnWaterF0));
+  // Total Column Water (TCW)
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf100"), kFmiTotalColumnWaterF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf99"), kFmiTotalColumnWaterF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf975"), kFmiTotalColumnWaterF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf95"), kFmiTotalColumnWaterF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf875"), kFmiTotalColumnWaterF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf50"), kFmiTotalColumnWaterF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf125"), kFmiTotalColumnWaterF12_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf5"), kFmiTotalColumnWaterF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf025"), kFmiTotalColumnWaterF2_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf1"), kFmiTotalColumnWaterF1));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("tcwf0"), kFmiTotalColumnWaterF0));
 
-    // Wind gust
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf100"), kFmiWindGustF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf99"), kFmiWindGustF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf975"), kFmiWindGustF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf95"), kFmiWindGustF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf875"), kFmiWindGustF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf50"), kFmiWindGustF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf125"), kFmiWindGustF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf5"), kFmiWindGustF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf025"), kFmiWindGustF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf1"), kFmiWindGustF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf0"), kFmiWindGustF0));
+  // Wind gust
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf100"), kFmiWindGustF100));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf99"), kFmiWindGustF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf975"), kFmiWindGustF97_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf95"), kFmiWindGustF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf875"), kFmiWindGustF87_5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf50"), kFmiWindGustF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf125"), kFmiWindGustF12_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf5"), kFmiWindGustF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf025"), kFmiWindGustF2_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf1"), kFmiWindGustF1));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("gustf0"), kFmiWindGustF0));
 
-    // Wind speed
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf100"), kFmiWindSpeedF100));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf99"), kFmiWindSpeedF99));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf975"), kFmiWindSpeedF97_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf95"), kFmiWindSpeedF95));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf875"), kFmiWindSpeedF87_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf50"), kFmiWindSpeedF50));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf125"), kFmiWindSpeedF12_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf5"), kFmiWindSpeedF5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf025"), kFmiWindSpeedF2_5));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf1"), kFmiWindSpeedF1));
-    paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf0"), kFmiWindSpeedF0));
+  // Wind speed
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf100"), kFmiWindSpeedF100));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf99"), kFmiWindSpeedF99));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf975"), kFmiWindSpeedF97_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf95"), kFmiWindSpeedF95));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf875"), kFmiWindSpeedF87_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf50"), kFmiWindSpeedF50));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf125"), kFmiWindSpeedF12_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf5"), kFmiWindSpeedF5));
+  paramMap.insert(
+      NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf025"), kFmiWindSpeedF2_5));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf1"), kFmiWindSpeedF1));
+  paramMap.insert(NFmiSmartToolIntepreter::ParamMap::value_type(string("wsf0"), kFmiWindSpeedF0));
 }
 
 void NFmiSmartToolIntepreter::InitTokens(NFmiProducerSystem *theProducerSystem,
@@ -3317,5 +3379,4 @@ void NFmiSmartToolIntepreter::InitTokens(NFmiProducerSystem *theProducerSystem,
 
     // clang-format on
   }
-
 }

--- a/smarttools/NFmiSmartToolIntepreter.h
+++ b/smarttools/NFmiSmartToolIntepreter.h
@@ -27,13 +27,13 @@
 // jälkeen pitää tulla calculationSection.
 //**********************************************************
 
-#include <newbase/NFmiParameterName.h>
-#include <newbase/NFmiProducerName.h>
 #include <newbase/NFmiAreaMask.h>
-#include <newbase/NFmiProducer.h>
+#include <newbase/NFmiDataMatrix.h>
 #include <newbase/NFmiLevelType.h>
 #include <newbase/NFmiParamBag.h>
-#include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiParameterName.h>
+#include <newbase/NFmiProducer.h>
+#include <newbase/NFmiProducerName.h>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/tuple/tuple.hpp>
@@ -62,6 +62,7 @@ class NFmiSmartToolCalculationBlockInfoVector
   Iterator Begin(void) { return itsCalculationBlockInfos.begin(); };
   Iterator End(void) { return itsCalculationBlockInfos.end(); };
   bool Empty(void) const { return itsCalculationBlockInfos.empty(); }
+
  private:
   // luokka ei omista vektorissa olevia otuksia, Clear pitää kutsua erikseen!!!
   checkedVector<boost::shared_ptr<NFmiSmartToolCalculationBlockInfo> > itsCalculationBlockInfos;
@@ -115,7 +116,6 @@ class NFmiSmartToolIntepreter
   std::unique_ptr<NFmiExtraMacroParamData> GetOwnershipOfExtraMacroParamData();
 
  private:
-
   bool CheckoutPossibleNextCalculationBlockVector(
       boost::shared_ptr<NFmiSmartToolCalculationBlockInfoVector> &theBlockVector);
   bool CheckoutPossibleNextCalculationBlock(NFmiSmartToolCalculationBlockInfo &theBlock,

--- a/smarttools/NFmiSmartToolModifier.cpp
+++ b/smarttools/NFmiSmartToolModifier.cpp
@@ -8,11 +8,13 @@
 #pragma warning(disable : 4786)  // poistaa n kpl VC++ kääntäjän varoitusta
 #endif
 
+#include "NFmiSmartToolModifier.h"
 #include "NFmiAreaMaskInfo.h"
 #include "NFmiAreaMaskSectionInfo.h"
 #include "NFmiCalculationConstantValue.h"
 #include "NFmiDictionaryFunction.h"
 #include "NFmiDrawParam.h"
+#include "NFmiExtraMacroParamData.h"
 #include "NFmiInfoAreaMaskSoundingIndex.h"
 #include "NFmiInfoOrganizer.h"
 #include "NFmiMetEditorTypes.h"
@@ -22,15 +24,13 @@
 #include "NFmiSmartToolCalculationSection.h"
 #include "NFmiSmartToolCalculationSectionInfo.h"
 #include "NFmiSmartToolIntepreter.h"
-#include "NFmiSmartToolModifier.h"
-#include "NFmiExtraMacroParamData.h"
 
+#include "NFmiInfoAreaMaskOccurrance.h"
 #include <newbase/NFmiBitMask.h>
 #include <newbase/NFmiCalculatedAreaMask.h>
 #include <newbase/NFmiDataModifierClasses.h>
 #include <newbase/NFmiFastQueryInfo.h>
 #include <newbase/NFmiInfoAreaMask.h>
-#include "NFmiInfoAreaMaskOccurrance.h"
 #include <newbase/NFmiQueryData.h>
 #include <newbase/NFmiQueryDataUtil.h>
 #include <newbase/NFmiRelativeDataIterator.h>
@@ -42,8 +42,8 @@
 #pragma warning( \
     disable : 4244 4267 4512)  // boost:in thread kirjastosta tulee ikävästi 4244 varoituksia
 #endif
-#include <boost/thread.hpp>
 #include "NFmiStation2GridMask.h"
+#include <boost/thread.hpp>
 
 #ifdef _MSC_VER
 #pragma warning(default : 4244 4267 4512)  // laitetaan 4244 takaisin päälle, koska se on tärkeä
@@ -75,9 +75,7 @@ NFmiSmartToolCalculationBlockVector::NFmiSmartToolCalculationBlockVector(
 {
 }
 
-NFmiSmartToolCalculationBlockVector::~NFmiSmartToolCalculationBlockVector(void)
-{
-}
+NFmiSmartToolCalculationBlockVector::~NFmiSmartToolCalculationBlockVector(void) {}
 
 boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolCalculationBlockVector::FirstVariableInfo(void)
 {
@@ -164,44 +162,31 @@ NFmiSmartToolCalculationBlock::NFmiSmartToolCalculationBlock(
 {
 }
 
-NFmiSmartToolCalculationBlock::~NFmiSmartToolCalculationBlock(void)
-{
-}
+NFmiSmartToolCalculationBlock::~NFmiSmartToolCalculationBlock(void) {}
 
 boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolCalculationBlock::FirstVariableInfo(void)
 {
   boost::shared_ptr<NFmiFastQueryInfo> info;
-  if (itsFirstCalculationSection)
-    info = itsFirstCalculationSection->FirstVariableInfo();
-  if (info == 0 && itsIfCalculationBlocks)
-    info = itsIfCalculationBlocks->FirstVariableInfo();
+  if (itsFirstCalculationSection) info = itsFirstCalculationSection->FirstVariableInfo();
+  if (info == 0 && itsIfCalculationBlocks) info = itsIfCalculationBlocks->FirstVariableInfo();
   if (info == 0 && itsElseIfCalculationBlocks)
     info = itsElseIfCalculationBlocks->FirstVariableInfo();
-  if (info == 0 && itsElseCalculationBlocks)
-    info = itsElseCalculationBlocks->FirstVariableInfo();
-  if (info == 0 && itsLastCalculationSection)
-    info = itsLastCalculationSection->FirstVariableInfo();
+  if (info == 0 && itsElseCalculationBlocks) info = itsElseCalculationBlocks->FirstVariableInfo();
+  if (info == 0 && itsLastCalculationSection) info = itsLastCalculationSection->FirstVariableInfo();
   return info;
 }
 
 void NFmiSmartToolCalculationBlock::Time(const NFmiMetTime &theTime)
 {
-  if (itsFirstCalculationSection)
-    itsFirstCalculationSection->SetTime(theTime);
+  if (itsFirstCalculationSection) itsFirstCalculationSection->SetTime(theTime);
 
-  if (itsIfAreaMaskSection)
-    itsIfAreaMaskSection->Time(theTime);
-  if (itsIfCalculationBlocks)
-    itsIfCalculationBlocks->SetTime(theTime);
-  if (itsElseIfAreaMaskSection)
-    itsElseIfAreaMaskSection->Time(theTime);
-  if (itsElseIfCalculationBlocks)
-    itsElseIfCalculationBlocks->SetTime(theTime);
-  if (itsElseCalculationBlocks)
-    itsElseCalculationBlocks->SetTime(theTime);
+  if (itsIfAreaMaskSection) itsIfAreaMaskSection->Time(theTime);
+  if (itsIfCalculationBlocks) itsIfCalculationBlocks->SetTime(theTime);
+  if (itsElseIfAreaMaskSection) itsElseIfAreaMaskSection->Time(theTime);
+  if (itsElseIfCalculationBlocks) itsElseIfCalculationBlocks->SetTime(theTime);
+  if (itsElseCalculationBlocks) itsElseCalculationBlocks->SetTime(theTime);
 
-  if (itsLastCalculationSection)
-    itsLastCalculationSection->SetTime(theTime);
+  if (itsLastCalculationSection) itsLastCalculationSection->SetTime(theTime);
 }
 
 void NFmiSmartToolCalculationBlock::Calculate(const NFmiCalculationParams &theCalculationParams,
@@ -239,8 +224,7 @@ void NFmiSmartToolCalculationBlock::Calculate_ver2(
 
   if (fDoMiddlePartOnly == false)
   {
-    if (itsLastCalculationSection)
-      itsLastCalculationSection->Calculate_ver2(theCalculationParams);
+    if (itsLastCalculationSection) itsLastCalculationSection->Calculate_ver2(theCalculationParams);
   }
 }
 
@@ -264,9 +248,7 @@ NFmiSmartToolModifier::NFmiSmartToolModifier(NFmiInfoOrganizer *theInfoOrganizer
       itsGriddingHelper(0)
 {
 }
-NFmiSmartToolModifier::~NFmiSmartToolModifier(void)
-{
-}
+NFmiSmartToolModifier::~NFmiSmartToolModifier(void) {}
 //--------------------------------------------------------
 // InitSmartTool
 //--------------------------------------------------------
@@ -701,8 +683,7 @@ void NFmiSmartToolModifier::ModifyConditionalData(
           NFmiQueryDataUtil::DoStepIt(
               theThreadCallBacks);  // stepataan vasta 0-tarkastuksen jälkeen!
           calculationParams.itsTime = modifiedTimes.Time();
-          if (theMacroParamValue.fSetValue)
-            calculationParams.itsTime = theMacroParamValue.itsTime;
+          if (theMacroParamValue.fSetValue) calculationParams.itsTime = theMacroParamValue.itsTime;
           calculationParams.itsTimeIndex = info->TimeIndex();
           theCalculationBlock->itsIfAreaMaskSection->Time(
               calculationParams.itsTime);  // yritetään optimoida laskuja hieman kun mahdollista
@@ -875,8 +856,7 @@ void NFmiSmartToolModifier::ModifyConditionalData_ver2(
       throw runtime_error(::GetDictionaryString("SmartToolModifierErrorUnknownProblem"));
     boost::shared_ptr<NFmiFastQueryInfo> info(
         dynamic_cast<NFmiFastQueryInfo *>(theCalculationBlock->FirstVariableInfo()->Clone()));
-    if (info == 0)
-      return;
+    if (info == 0) return;
 
     try
     {
@@ -980,8 +960,7 @@ void NFmiSmartToolModifier::ModifyData2(
   {
     boost::shared_ptr<NFmiFastQueryInfo> info(
         dynamic_cast<NFmiFastQueryInfo *>(theCalculationSection->FirstVariableInfo()->Clone()));
-    if (info == 0)
-      return;
+    if (info == 0) return;
     try
     {
       NFmiCalculationParams calculationParams;
@@ -1005,8 +984,7 @@ void NFmiSmartToolModifier::ModifyData2(
         for (modifiedTimes.Reset(); modifiedTimes.Next();)
         {
           calculationParams.itsTime = modifiedTimes.Time();
-          if (theMacroParamValue.fSetValue)
-            calculationParams.itsTime = theMacroParamValue.itsTime;
+          if (theMacroParamValue.fSetValue) calculationParams.itsTime = theMacroParamValue.itsTime;
           if (info->Time(
                   calculationParams.itsTime))  // asetetaan myös tämä, että saadaan oikea timeindex
           {
@@ -1032,12 +1010,10 @@ void NFmiSmartToolModifier::ModifyData2(
               theCalculationSection->GetCalculations()[i]->Calculate(calculationParams,
                                                                      theMacroParamValue);
 
-              if (theMacroParamValue.fSetValue)
-                break;
+              if (theMacroParamValue.fSetValue) break;
             }
           }
-          if (theMacroParamValue.fSetValue)
-            break;
+          if (theMacroParamValue.fSetValue) break;
         }
       }
     }
@@ -1056,8 +1032,7 @@ void NFmiSmartToolModifier::ModifyData2_ver2(
   {
     boost::shared_ptr<NFmiFastQueryInfo> info(
         dynamic_cast<NFmiFastQueryInfo *>(theCalculationSection->FirstVariableInfo()->Clone()));
-    if (info == 0)
-      return;
+    if (info == 0) return;
     try
     {
       info->LatLon();  // tämä on pyydettävä kerran multi-thread jutuissa, koska tämä rakentaa
@@ -1188,8 +1163,7 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreatePeekFunctionAreaMas
         theAreaMaskInfo.GetOffsetPoint1().Y(),
         NFmiAreaMask::kNoValue));
 
-  if (fUseLevelData)
-    itsParethesisCounter++;
+  if (fUseLevelData) itsParethesisCounter++;
 
   return areaMask;
 }
@@ -1344,8 +1318,7 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateInfoVariableMask(
 boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateRampFunctionMask(
     const NFmiAreaMaskInfo &theAreaMaskInfo, bool &mustUsePressureInterpolation)
 {
-  if (fUseLevelData)
-    itsParethesisCounter++;
+  if (fUseLevelData) itsParethesisCounter++;
   NFmiInfoData::Type type = theAreaMaskInfo.GetDataType();
   if (type != NFmiInfoData::kCalculatedValue)
   {
@@ -1381,8 +1354,7 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateAreaIntegrationMask
     info = tmp;
   }
 
-  if (fUseLevelData)
-    itsParethesisCounter++;
+  if (fUseLevelData) itsParethesisCounter++;
 
   int startX = static_cast<int>(theAreaMaskInfo.GetOffsetPoint1().X());
   int startY = static_cast<int>(theAreaMaskInfo.GetOffsetPoint1().Y());
@@ -1414,8 +1386,7 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateAreaIntegrationMask
 boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateStartParenthesisMask(
     const NFmiAreaMaskInfo &theAreaMaskInfo)
 {
-  if (fUseLevelData)
-    itsParethesisCounter++;
+  if (fUseLevelData) itsParethesisCounter++;
   return boost::shared_ptr<NFmiAreaMask>(
       new NFmiCalculationSpecialCase(theAreaMaskInfo.GetCalculationOperator()));
 }
@@ -1460,8 +1431,7 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateMathFunctionStartMa
   boost::shared_ptr<NFmiAreaMask> areaMask =
       boost::shared_ptr<NFmiAreaMask>(new NFmiCalculationSpecialCase());
   areaMask->SetMathFunctionType(theAreaMaskInfo.GetMathFunctionType());
-  if (fUseLevelData)
-    itsParethesisCounter++;
+  if (fUseLevelData) itsParethesisCounter++;
   return areaMask;
 }
 
@@ -1487,8 +1457,7 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateOccurrenceMask(
 {
   bool synopXCase =
       theAreaMaskInfo.GetDataIdent().GetProducer()->GetIdent() == NFmiInfoData::kFmiSpSynoXProducer;
-  if (synopXCase)
-    theAreaMaskInfo.GetDataIdent().GetProducer()->SetIdent(kFmiSYNOP);
+  if (synopXCase) theAreaMaskInfo.GetDataIdent().GetProducer()->SetIdent(kFmiSYNOP);
   boost::shared_ptr<NFmiFastQueryInfo> info =
       CreateInfo(theAreaMaskInfo, mustUsePressureInterpolation);
   boost::shared_ptr<NFmiArea> calculationArea(UsedMacroParamData()->Area()->Clone());
@@ -1908,8 +1877,7 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateCalculatedAreaMask(
         theAreaMaskInfo.GetMaskCondition(),
         false));
 
-  if (areaMask)
-    return areaMask;
+  if (areaMask) return areaMask;
 
   throw runtime_error(::GetDictionaryString("SmartToolModifierErrorStrangeVariable"));
 }
@@ -1984,10 +1952,8 @@ boost::shared_ptr<NFmiAreaMask> NFmiSmartToolModifier::CreateEndingAreaMask(void
 
 static bool IsBetweenValues(double value, double value1, double value2)
 {
-  if (value >= value1 && value <= value2)
-    return true;
-  if (value >= value2 && value <= value1)
-    return true;
+  if (value >= value1 && value <= value2) return true;
+  if (value >= value2 && value <= value1) return true;
   return false;
 }
 
@@ -2048,8 +2014,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolModifier::GetPossibleLevelInte
     {
       checkedVector<boost::shared_ptr<NFmiFastQueryInfo> > infos =
           itsInfoOrganizer->GetInfos(info->DataFilePattern());
-      if (infos.size())
-        info = infos[0];
+      if (infos.size()) info = infos[0];
     }
 
     info = NFmiSmartInfo::CreateShallowCopyOfHighestInfo(info);
@@ -2108,8 +2073,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolModifier::GetWantedAreaMaskDat
     FmiLevelType theOverRideLevelType)
 {
   NFmiInfoData::Type usedDataType = theAreaMaskInfo.GetDataType();
-  if (theOverRideDataType != NFmiInfoData::kNoDataType)
-    usedDataType = theOverRideDataType;
+  if (theOverRideDataType != NFmiInfoData::kNoDataType) usedDataType = theOverRideDataType;
 
   boost::shared_ptr<NFmiFastQueryInfo> info;
   if (theOverRideLevelType == kFmiNoLevelType)
@@ -2160,8 +2124,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolModifier::CreateInfo(
     else
     {
       info = GetWantedAreaMaskData(theAreaMaskInfo, true);
-      if (info && itsModifiedLevel)
-        info->Level(*itsModifiedLevel);
+      if (info && itsModifiedLevel) info->Level(*itsModifiedLevel);
     }
     if (info == 0)
       info = GetPossibleLevelInterpolatedInfo(theAreaMaskInfo, mustUsePressureInterpolation);
@@ -2176,8 +2139,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolModifier::CreateInfo(
     if (fUseLevelData || fDoCrossSectionCalculation)  // jos leveldata-flagi päällä, yritetään
                                                       // ensin, löytyykö hybridi dataa
       info = GetWantedAreaMaskData(theAreaMaskInfo, false, NFmiInfoData::kHybridData);
-    if (info == 0)
-      info = GetWantedAreaMaskData(theAreaMaskInfo, false);
+    if (info == 0) info = GetWantedAreaMaskData(theAreaMaskInfo, false);
     if (info == 0 &&
         theAreaMaskInfo.GetDataType() ==
             NFmiInfoData::kAnalyzeData)  // analyysi datalle piti tehdä pika viritys tähän
@@ -2276,8 +2238,7 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolModifier::CreateScriptVariable
     {
       itsScriptVariableInfos.push_back(tmp2);
       tmp = GetScriptVariableInfo(theDataIdent);
-      if (tmp)
-        return NFmiSmartInfo::CreateShallowCopyOfHighestInfo(tmp);
+      if (tmp) return NFmiSmartInfo::CreateShallowCopyOfHighestInfo(tmp);
     }
   }
 
@@ -2293,15 +2254,11 @@ boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolModifier::GetScriptVariableInf
       std::find_if(itsScriptVariableInfos.begin(),
                    itsScriptVariableInfos.end(),
                    FindScriptVariable(theDataIdent.GetParamIdent()));
-  if (it != itsScriptVariableInfos.end())
-    return *it;
+  if (it != itsScriptVariableInfos.end()) return *it;
   return boost::shared_ptr<NFmiFastQueryInfo>();
 }
 
-void NFmiSmartToolModifier::ClearScriptVariableInfos(void)
-{
-  itsScriptVariableInfos.clear();
-}
+void NFmiSmartToolModifier::ClearScriptVariableInfos(void) { itsScriptVariableInfos.clear(); }
 
 boost::shared_ptr<NFmiFastQueryInfo> NFmiSmartToolModifier::CreateRealScriptVariableInfo(
     const NFmiDataIdent &theDataIdent)

--- a/smarttools/NFmiSmartToolModifier.h
+++ b/smarttools/NFmiSmartToolModifier.h
@@ -18,12 +18,12 @@
 // laskut suoritetaan.
 //**********************************************************
 
-#include <newbase/NFmiParamBag.h>
+#include <boost/shared_ptr.hpp>
+#include <newbase/NFmiAreaMask.h>
 #include <newbase/NFmiDataMatrix.h>
 #include <newbase/NFmiInfoData.h>
 #include <newbase/NFmiLevelType.h>
-#include <newbase/NFmiAreaMask.h>
-#include <boost/shared_ptr.hpp>
+#include <newbase/NFmiParamBag.h>
 #include <string>
 
 class NFmiInfoOrganizer;
@@ -68,6 +68,7 @@ class NFmiSmartToolCalculationBlockVector
   void Add(const boost::shared_ptr<NFmiSmartToolCalculationBlock> &theBlock);
   Iterator Begin(void) { return itsCalculationBlocks.begin(); }
   Iterator End(void) { return itsCalculationBlocks.end(); }
+
  private:
   // luokka ei omista vektorissa olevia otuksia, Clear pitää kutsua erikseen!!!
   checkedVector<boost::shared_ptr<NFmiSmartToolCalculationBlock> > itsCalculationBlocks;

--- a/smarttools/NFmiSmartToolUtil.cpp
+++ b/smarttools/NFmiSmartToolUtil.cpp
@@ -9,9 +9,9 @@
                                  // merkkiä joka johtuu 'puretuista' STL-template nimistä)
 #endif
 
+#include "NFmiSmartToolUtil.h"
 #include "NFmiInfoOrganizer.h"
 #include "NFmiSmartToolModifier.h"
-#include "NFmiSmartToolUtil.h"
 #include <newbase/NFmiFastQueryInfo.h>
 #include <newbase/NFmiQueryData.h>
 #include <newbase/NFmiStreamQueryData.h>
@@ -109,8 +109,7 @@ NFmiQueryData *NFmiSmartToolUtil::ModifyData(
   }
 
   NFmiQueryData *data = 0;
-  if (editedInfo && editedInfo->RefQueryData())
-    data = editedInfo->RefQueryData()->Clone();
+  if (editedInfo && editedInfo->RefQueryData()) data = editedInfo->RefQueryData()->Clone();
   return data;
 }
 
@@ -152,8 +151,7 @@ std::string NFmiSmartToolUtil::GetWorkingDirectory(void)
   return workingDirectory;
 #else
   static char path[4096];  // we assume 4096 is maximum buffer length
-  if (!::getcwd(path, 4096))
-    throw std::runtime_error("Error: Current path is too long (>4096)");
+  if (!::getcwd(path, 4096)) throw std::runtime_error("Error: Current path is too long (>4096)");
   return std::string(path);
 #endif
 }

--- a/smarttools/NFmiSortedPtrList.h
+++ b/smarttools/NFmiSortedPtrList.h
@@ -46,8 +46,7 @@ class NFmiSortedPtrList : public NFmiPtrList<Type>
       typename NFmiPtrList<Type>::Iterator tempIter = this->Start();
       while (tempIter.Next())
       {
-        if (*theItem < tempIter.Current())
-          return tempIter.AddBefore(theItem);
+        if (*theItem < tempIter.Current()) return tempIter.AddBefore(theItem);
       }
       return this->AddEnd(theItem);
     }
@@ -78,8 +77,7 @@ class NFmiSortedPtrList : public NFmiPtrList<Type>
     typename NFmiPtrList<Type>::Iterator theIter = this->Start();
     while (theIter.Next())
     {
-      if (theIter.Current() == *theItem)
-        return theIter;
+      if (theIter.Current() == *theItem) return theIter;
     }
     return theIter;
   };
@@ -88,4 +86,3 @@ class NFmiSortedPtrList : public NFmiPtrList<Type>
  private:
   bool fAscending;  //   Määrää listan järjestyksen (true = nouseva).
 };
-

--- a/smarttools/NFmiSoundingData.cpp
+++ b/smarttools/NFmiSoundingData.cpp
@@ -12,10 +12,10 @@
 
 #include <newbase/NFmiAngle.h>
 #include <newbase/NFmiDataModifierAvg.h>
+#include <newbase/NFmiFastInfoUtils.h>
 #include <newbase/NFmiFastQueryInfo.h>
 #include <newbase/NFmiInterpolation.h>
 #include <newbase/NFmiValueString.h>
-#include <newbase/NFmiFastInfoUtils.h>
 
 using namespace NFmiSoundingFunctions;
 
@@ -60,8 +60,7 @@ bool NFmiSoundingData::GetTandTdValuesFromNearestPressureLevel(double P,
       bool foundLevel = false;
       for (int i = 0; i < static_cast<int>(pV.size()); i++)
       {
-        if (i < 0)
-          return false;  // jos 'tyhjä' luotaus, on tässä aluksi -1 indeksinä
+        if (i < 0) return false;  // jos 'tyhjä' luotaus, on tässä aluksi -1 indeksinä
         if (pV[i] != kFloatMissing)
         {
           double pDiff = ::fabs(pV[i] - P);
@@ -75,8 +74,7 @@ bool NFmiSoundingData::GetTandTdValuesFromNearestPressureLevel(double P,
           }
         }
       }
-      if (foundLevel)
-        return true;
+      if (foundLevel) return true;
 
       theFoundP = kFloatMissing;  // 'nollataan' tämä vielä varmuuden vuoksi
     }
@@ -116,8 +114,7 @@ void NFmiSoundingData::SetTandTdSurfaceValues(float T, float Td)
 // paluttaa paine arvon halutulle metri korkeudelle
 float NFmiSoundingData::GetPressureAtHeight(double H)
 {
-  if (H == kFloatMissing)
-    return kFloatMissing;
+  if (H == kFloatMissing) return kFloatMissing;
 
   double maxDiffInH = 100;  // jos ei voi interpoloida, pitää löydetyn arvon olla vähintäin näin
                             // lähellä, että hyväksytään
@@ -150,8 +147,7 @@ float NFmiSoundingData::GetPressureAtHeight(double H)
         {
           lastP = currentP;
           lastH = currentH;
-          if (currentH == H)
-            return currentP;  // jos oli tarkka osuma, turha jatkaa
+          if (currentH == H) return currentP;  // jos oli tarkka osuma, turha jatkaa
         }
       }
     }
@@ -177,8 +173,7 @@ bool NFmiSoundingData::IsSameSounding(const NFmiSoundingData &theOtherSounding)
 {
   if (Location() == theOtherSounding.Location())
     if (Time() == theOtherSounding.Time())
-      if (OriginTime() == theOtherSounding.OriginTime())
-        return true;
+      if (OriginTime() == theOtherSounding.OriginTime()) return true;
   return false;
 }
 
@@ -209,8 +204,7 @@ bool NFmiSoundingData::GetLowestNonMissingValues(float &H, float &U, float &V)
 float NFmiSoundingData::GetValueAtHeight(FmiParameterName theId, float H)
 {
   float P = GetPressureAtHeight(H);
-  if (P == kFloatMissing)
-    return kFloatMissing;
+  if (P == kFloatMissing) return kFloatMissing;
 
   return GetValueAtPressure(theId, P);
 }
@@ -218,8 +212,7 @@ float NFmiSoundingData::GetValueAtHeight(FmiParameterName theId, float H)
 // Hakee halutun parametrin arvon halutulta painekorkeudelta.
 float NFmiSoundingData::GetValueAtPressure(FmiParameterName theId, float P)
 {
-  if (P == kFloatMissing)
-    return kFloatMissing;
+  if (P == kFloatMissing) return kFloatMissing;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &paramV = GetParamData(theId);
@@ -239,15 +232,13 @@ float NFmiSoundingData::GetValueAtPressure(FmiParameterName theId, float P)
       {
         if (currentP < P)
         {
-          if (currentValue != kFloatMissing)
-            break;
+          if (currentValue != kFloatMissing) break;
         }
         if (currentValue != kFloatMissing)
         {
           lastP = currentP;
           lastValue = currentValue;
-          if (currentP == P)
-            return currentValue;  // jos oli tarkka osuma, turha jatkaa
+          if (currentP == P) return currentValue;  // jos oli tarkka osuma, turha jatkaa
         }
       }
     }
@@ -263,13 +254,11 @@ float NFmiSoundingData::GetValueAtPressure(FmiParameterName theId, float P)
     }
     else if (lastP != kFloatMissing && lastValue != kFloatMissing)
     {
-      if (::fabs(lastP - P) < maxPDiff)
-        value = lastValue;
+      if (::fabs(lastP - P) < maxPDiff) value = lastValue;
     }
     else if (currentP != kFloatMissing && currentValue != kFloatMissing)
     {
-      if (::fabs(currentP - P) < maxPDiff)
-        value = currentValue;
+      if (::fabs(currentP - P) < maxPDiff) value = currentValue;
     }
   }
   return value;
@@ -413,12 +402,10 @@ bool NFmiSoundingData::CalcLCLAvgValues(
         P = pV[i];
         break;
       }
-    if (P == kFloatMissing)
-      return false;
+    if (P == kFloatMissing) return false;
     int startP = static_cast<int>(round(GetPressureAtHeight(fromZ)));
     int endP = static_cast<int>(round(GetPressureAtHeight(toZ)));
-    if (startP == kFloatMissing || endP == kFloatMissing || startP <= endP)
-      return false;
+    if (startP == kFloatMissing || endP == kFloatMissing || startP <= endP) return false;
     NFmiDataModifierAvg avgT;   // riippuen moodista tässä lasketaan T tai Tpot keskiarvoa
     NFmiDataModifierAvg avgTd;  // riippuen moodista tässä lasketaan Td tai w keskiarvoa
     for (int pressure = startP; pressure > endP;
@@ -507,8 +494,7 @@ bool NFmiSoundingData::FillParamData(const boost::shared_ptr<NFmiFastQueryInfo> 
       if (theInfo->HeightParamIsRising() ==
           false)  // jos ei nousevassa järjestyksessä, käännetään vektorissa olevat arvot
         std::reverse(data.begin(), data.end());
-      if (theId == kFmiPressure)
-        fPressureDataAvailable = true;
+      if (theId == kFmiPressure) fPressureDataAvailable = true;
       if (theId == kFmiGeomHeight || theId == kFmiGeopHeight || theId == kFmiFlAltitude)
         fHeightDataAvailable = true;
       return true;
@@ -541,8 +527,7 @@ bool NFmiSoundingData::FillParamData(const boost::shared_ptr<NFmiFastQueryInfo> 
   else if (theId == kFmiDewPoint && theInfo->Param(kFmiHumidity))
   {
     unsigned int RHindex = theInfo->ParamIndex();
-    if (!theInfo->Param(kFmiTemperature))
-      return false;
+    if (!theInfo->Param(kFmiTemperature)) return false;
     unsigned int Tindex = theInfo->ParamIndex();
     float T = 0;
     float RH = 0;
@@ -587,8 +572,7 @@ unsigned int NFmiSoundingData::GetHighestNonMissingValueLevelIndex(FmiParameterN
   std::deque<float>::size_type ssize = vec.size();
   unsigned int index = 0;
   for (unsigned int i = 0; i < ssize; i++)
-    if (vec[i] != kFloatMissing)
-      index = i;
+    if (vec[i] != kFloatMissing) index = i;
   return index;
 }
 
@@ -610,8 +594,7 @@ void NFmiSoundingData::CutEmptyData(void)
   for (unsigned int i = 0; i < itsSoundingParameters.size(); i++)
   {
     unsigned int currentIndex = GetHighestNonMissingValueLevelIndex(itsSoundingParameters[i]);
-    if (currentIndex > greatestNonMissingLevelIndex)
-      greatestNonMissingLevelIndex = currentIndex;
+    if (currentIndex > greatestNonMissingLevelIndex) greatestNonMissingLevelIndex = currentIndex;
     if (greatestNonMissingLevelIndex >= maxLevelIndex)
       return;  // ei tarvitse leikata, kun dataa löytyy korkeimmaltakin leveliltä
   }
@@ -931,8 +914,7 @@ void NFmiSoundingData::ClearDatas(void)
 
 bool NFmiSoundingData::ModifyT2DryAdiapaticBelowGivenP(double P, double T)
 {
-  if (P == kFloatMissing || T == kFloatMissing)
-    return false;
+  if (P == kFloatMissing || T == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &tV = GetParamData(kFmiTemperature);
@@ -959,8 +941,7 @@ bool NFmiSoundingData::ModifyT2DryAdiapaticBelowGivenP(double P, double T)
 
 bool NFmiSoundingData::ModifyTd2MixingRatioBelowGivenP(double P, double T, double Td)
 {
-  if (P == kFloatMissing || Td == kFloatMissing)
-    return false;
+  if (P == kFloatMissing || Td == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &tV = GetParamData(kFmiTemperature);
@@ -988,8 +969,7 @@ bool NFmiSoundingData::ModifyTd2MixingRatioBelowGivenP(double P, double T, doubl
 
 bool NFmiSoundingData::ModifyTd2MoistAdiapaticBelowGivenP(double P, double Td)
 {
-  if (P == kFloatMissing || Td == kFloatMissing)
-    return false;
+  if (P == kFloatMissing || Td == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &tdV = GetParamData(kFmiDewPoint);
@@ -1031,10 +1011,8 @@ static float FixValuesWithLimits(float theValue, float minValue, float maxValue)
 {
   if (theValue != kFloatMissing)
   {
-    if (minValue != kFloatMissing)
-      theValue = FmiMax(theValue, minValue);
-    if (maxValue != kFloatMissing)
-      theValue = FmiMin(theValue, maxValue);
+    if (minValue != kFloatMissing) theValue = FmiMax(theValue, minValue);
+    if (maxValue != kFloatMissing) theValue = FmiMin(theValue, maxValue);
   }
   return theValue;
 }
@@ -1046,8 +1024,7 @@ bool NFmiSoundingData::Add2ParamAtNearestP(float P,
                                            float maxValue,
                                            bool fCircularValue)
 {
-  if (P == kFloatMissing)
-    return false;
+  if (P == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &paramV = GetParamData(parId);
@@ -1070,8 +1047,7 @@ bool NFmiSoundingData::Add2ParamAtNearestP(float P,
           closestIndex = i;
         }
       }
-      if (currentP < P && closestPdiff != kFloatMissing)
-        break;
+      if (currentP < P && closestPdiff != kFloatMissing) break;
     }
 
     if (closestPdiff != kFloatMissing)
@@ -1255,8 +1231,7 @@ double NFmiSoundingData::CalcCTOTIndex(void)
 {
   double T500 = GetValueAtPressure(kFmiTemperature, 500);
   double TD850 = GetValueAtPressure(kFmiDewPoint, 850);
-  if (T500 != kFloatMissing && TD850 != kFloatMissing)
-    return (TD850 - T500);
+  if (T500 != kFloatMissing && TD850 != kFloatMissing) return (TD850 - T500);
   return kFloatMissing;
 }
 
@@ -1268,8 +1243,7 @@ double NFmiSoundingData::CalcVTOTIndex(void)
 {
   double T500 = GetValueAtPressure(kFmiTemperature, 500);
   double T850 = GetValueAtPressure(kFmiTemperature, 850);
-  if (T500 != kFloatMissing && T850 != kFloatMissing)
-    return (T850 - T500);
+  if (T500 != kFloatMissing && T850 != kFloatMissing) return (T850 - T500);
   return kFloatMissing;
 }
 
@@ -1325,8 +1299,7 @@ double NFmiSoundingData::CalcLCLPressureLevel(FmiLCLCalcType theLCLCalcType)
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   return CalcLCLPressure(T, Td, P);
 }
@@ -1354,8 +1327,7 @@ double NFmiSoundingData::CalcLFCIndex(FmiLCLCalcType theLCLCalcType, double &EL)
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   double LCLValue = CalcLCLPressure(T, Td, P);
   // 2. lift parcel until its warmer than environment
@@ -1409,12 +1381,10 @@ double NFmiSoundingData::CalcCAPE500Index(FmiLCLCalcType theLCLCalcType, double 
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   // HUOM! Pitää ottaa huomioon aseman korkeus kun tehdään laskuja!!!!
-  if (theHeightLimit != kFloatMissing)
-    theHeightLimit += ZeroHeight();
+  if (theHeightLimit != kFloatMissing) theHeightLimit += ZeroHeight();
 
   std::deque<float> &pValues = GetParamData(kFmiPressure);
   std::deque<float> &tValues = GetParamData(kFmiTemperature);
@@ -1461,8 +1431,7 @@ double NFmiSoundingData::CalcCAPE_TT_Index(FmiLCLCalcType theLCLCalcType, double
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   std::deque<float> &pValues = GetParamData(kFmiPressure);
   std::deque<float> &tValues = GetParamData(kFmiTemperature);
@@ -1509,8 +1478,7 @@ double NFmiSoundingData::CalcCINIndex(FmiLCLCalcType theLCLCalcType)
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   std::deque<float> &pValues = GetParamData(kFmiPressure);
   std::deque<float> &tValues = GetParamData(kFmiTemperature);
@@ -1553,8 +1521,7 @@ double NFmiSoundingData::CalcCINIndex(FmiLCLCalcType theLCLCalcType)
       }
     }
   }
-  if (!(firstCinLayerFound && capeLayerFoundAfterCin))
-    CIN = 0;
+  if (!(firstCinLayerFound && capeLayerFoundAfterCin)) CIN = 0;
   return CIN;
 }
 
@@ -1571,8 +1538,7 @@ double NFmiSoundingData::CalcWindBulkShearComponent(double startH,
   float startValue = GetValueAtHeight(theParId, static_cast<float>(startH * 1000));
   float endValue = GetValueAtHeight(theParId, static_cast<float>(endH * 1000));
   float shearComponent = endValue - startValue;
-  if (endValue == kFloatMissing || startValue == kFloatMissing)
-    shearComponent = kFloatMissing;
+  if (endValue == kFloatMissing || startValue == kFloatMissing) shearComponent = kFloatMissing;
   return shearComponent;
 }
 
@@ -1596,8 +1562,7 @@ double NFmiSoundingData::CalcThetaEDiffIndex(double startH, double endH)
   if (endT == kFloatMissing || endTd == kFloatMissing || endP == kFloatMissing)
     return kFloatMissing;
   double endThetaE = CalcThetaE(endT, endTd, endP);
-  if (startThetaE == kFloatMissing || endThetaE == kFloatMissing)
-    return kFloatMissing;
+  if (startThetaE == kFloatMissing || endThetaE == kFloatMissing) return kFloatMissing;
   double diffValue = startThetaE - endThetaE;
   return diffValue;
 }
@@ -1610,8 +1575,7 @@ double NFmiSoundingData::CalcBulkShearIndex(double startH, double endH)
   double uTot = CalcWindBulkShearComponent(startH, endH, kFmiWindUMS);
   double vTot = CalcWindBulkShearComponent(startH, endH, kFmiWindVMS);
   double BS = ::sqrt(uTot * uTot + vTot * vTot);
-  if (uTot == kFloatMissing || vTot == kFloatMissing)
-    BS = kFloatMissing;
+  if (uTot == kFloatMissing || vTot == kFloatMissing) BS = kFloatMissing;
   return BS;
 }
 
@@ -1649,11 +1613,11 @@ v_ID = v0_6 - shr_0_6_u_n * 7.5;
 (7.5 are meters per second... watch out when you work with knots instead)
 
 */  // **********
-                                                                                    // SRH
-                                                                                    // calculation
-                                                                                    // help from
-                                                                                    // Pieter
-                                                                                    // Groenemeijer
+    // SRH
+    // calculation
+    // help from
+    // Pieter
+    // Groenemeijer
 // ******************
 
 // I use same variable names as with the Pieters help evem though calculations are not

--- a/smarttools/NFmiSoundingData.h
+++ b/smarttools/NFmiSoundingData.h
@@ -9,17 +9,16 @@
 
 #pragma once
 
-#include <newbase/NFmiMetTime.h>
-#include <newbase/NFmiLocation.h>
-#include <newbase/NFmiParameterName.h>
 #include <boost/shared_ptr.hpp>
+#include <newbase/NFmiLocation.h>
+#include <newbase/NFmiMetTime.h>
+#include <newbase/NFmiParameterName.h>
 #include <deque>
 
 class NFmiFastQueryInfo;
 
 // Miten LCL lasketaan, pinta-arvojen vai mixed layer arvojen avulla, vai most unstable?
-typedef enum
-{
+typedef enum {
   kLCLCalcNone = 0,
   kLCLCalcSurface = 1,
   kLCLCalc500m = 2,
@@ -161,4 +160,3 @@ class NFmiSoundingData
   bool fPressureDataAvailable;
   bool fHeightDataAvailable;
 };
-

--- a/smarttools/NFmiSoundingDataOpt1.cpp
+++ b/smarttools/NFmiSoundingDataOpt1.cpp
@@ -11,11 +11,11 @@
 #include "NFmiSoundingFunctions.h"
 #include <newbase/NFmiAngle.h>
 #include <newbase/NFmiDataModifierAvg.h>
+#include <newbase/NFmiFastInfoUtils.h>
 #include <newbase/NFmiFastQueryInfo.h>
 #include <newbase/NFmiInterpolation.h>
-#include <newbase/NFmiValueString.h>
 #include <newbase/NFmiQueryDataUtil.h>
-#include <newbase/NFmiFastInfoUtils.h>
+#include <newbase/NFmiValueString.h>
 
 #include <fstream>
 
@@ -40,8 +40,7 @@ bool NFmiSoundingDataOpt1::GetTandTdValuesFromNearestPressureLevel(double P,
       bool foundLevel = false;
       for (int i = 0; i < static_cast<int>(pV.size()); i++)
       {
-        if (i < 0)
-          return false;  // jos 'tyhjä' luotaus, on tässä aluksi -1 indeksinä
+        if (i < 0) return false;  // jos 'tyhjä' luotaus, on tässä aluksi -1 indeksinä
         if (pV[i] != kFloatMissing)
         {
           double pDiff = ::fabs(pV[i] - P);
@@ -55,8 +54,7 @@ bool NFmiSoundingDataOpt1::GetTandTdValuesFromNearestPressureLevel(double P,
           }
         }
       }
-      if (foundLevel)
-        return true;
+      if (foundLevel) return true;
 
       theFoundP = kFloatMissing;  // 'nollataan' tämä vielä varmuuden vuoksi
     }
@@ -98,8 +96,7 @@ void NFmiSoundingDataOpt1::SetTandTdSurfaceValues(float T, float Td)
 // paluttaa paine arvon halutulle metri korkeudelle
 float NFmiSoundingDataOpt1::GetPressureAtHeight(double H)
 {
-  if (H == kFloatMissing)
-    return kFloatMissing;
+  if (H == kFloatMissing) return kFloatMissing;
 
   double maxDiffInH = 100;  // jos ei voi interpoloida, pitää löydetyn arvon olla vähintäin näin
                             // lähellä, että hyväksytään
@@ -132,8 +129,7 @@ float NFmiSoundingDataOpt1::GetPressureAtHeight(double H)
         {
           lastP = currentP;
           lastH = currentH;
-          if (currentH == H)
-            return currentP;  // jos oli tarkka osuma, turha jatkaa
+          if (currentH == H) return currentP;  // jos oli tarkka osuma, turha jatkaa
         }
       }
     }
@@ -159,8 +155,7 @@ bool NFmiSoundingDataOpt1::IsSameSounding(const NFmiSoundingDataOpt1 &theOtherSo
 {
   if (Location() == theOtherSounding.Location())
     if (Time() == theOtherSounding.Time())
-      if (OriginTime() == theOtherSounding.OriginTime())
-        return true;
+      if (OriginTime() == theOtherSounding.OriginTime()) return true;
   return false;
 }
 
@@ -191,8 +186,7 @@ bool NFmiSoundingDataOpt1::GetLowestNonMissingValues(float &H, float &U, float &
 float NFmiSoundingDataOpt1::GetValueAtHeight(FmiParameterName theId, float H)
 {
   float P = GetPressureAtHeight(H);
-  if (P == kFloatMissing)
-    return kFloatMissing;
+  if (P == kFloatMissing) return kFloatMissing;
 
   return GetValueAtPressure(theId, P);
 }
@@ -200,8 +194,7 @@ float NFmiSoundingDataOpt1::GetValueAtHeight(FmiParameterName theId, float H)
 // Hakee halutun parametrin arvon halutulta painekorkeudelta.
 float NFmiSoundingDataOpt1::GetValueAtPressure(FmiParameterName theId, float P)
 {
-  if (P == kFloatMissing)
-    return kFloatMissing;
+  if (P == kFloatMissing) return kFloatMissing;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &paramV = GetParamData(theId);
@@ -221,15 +214,13 @@ float NFmiSoundingDataOpt1::GetValueAtPressure(FmiParameterName theId, float P)
       {
         if (currentP < P)
         {
-          if (currentValue != kFloatMissing)
-            break;
+          if (currentValue != kFloatMissing) break;
         }
         if (currentValue != kFloatMissing)
         {
           lastP = currentP;
           lastValue = currentValue;
-          if (currentP == P)
-            return currentValue;  // jos oli tarkka osuma, turha jatkaa
+          if (currentP == P) return currentValue;  // jos oli tarkka osuma, turha jatkaa
         }
       }
     }
@@ -247,13 +238,11 @@ float NFmiSoundingDataOpt1::GetValueAtPressure(FmiParameterName theId, float P)
     }
     else if (lastP != kFloatMissing && lastValue != kFloatMissing)
     {
-      if (::fabs(lastP - P) < maxPDiff)
-        value = lastValue;
+      if (::fabs(lastP - P) < maxPDiff) value = lastValue;
     }
     else if (currentP != kFloatMissing && currentValue != kFloatMissing)
     {
-      if (::fabs(currentP - P) < maxPDiff)
-        value = currentValue;
+      if (::fabs(currentP - P) < maxPDiff) value = currentValue;
     }
   }
   return value;
@@ -370,8 +359,7 @@ static bool operator>(const ThetaEValues &theta1, const ThetaEValues &theta2)
 {
   if (theta1.P != kFloatMissing && theta2.P != kFloatMissing)
   {
-    if (theta1.P > theta2.P)
-      return true;
+    if (theta1.P > theta2.P) return true;
   }
   return false;
 }
@@ -597,12 +585,10 @@ bool NFmiSoundingDataOpt1::CalcLCLAvgValues(
         P = pV[i];
         break;
       }
-    if (P == kFloatMissing)
-      return false;
+    if (P == kFloatMissing) return false;
     int startP = static_cast<int>(round(GetPressureAtHeight(fromZ)));
     int endP = static_cast<int>(round(GetPressureAtHeight(toZ)));
-    if (startP == kFloatMissing || endP == kFloatMissing || startP <= endP)
-      return false;
+    if (startP == kFloatMissing || endP == kFloatMissing || startP <= endP) return false;
     NFmiDataModifierAvg avgT;   // riippuen moodista tässä lasketaan T tai Tpot keskiarvoa
     NFmiDataModifierAvg avgTd;  // riippuen moodista tässä lasketaan Td tai w keskiarvoa
     for (int pressure = startP; pressure > endP;
@@ -743,8 +729,7 @@ bool NFmiSoundingDataOpt1::LookForFilledParamFromInfo(
   bool paramFound = theInfo->Param(theId);
   // Kastepiste parametri voi tulla luotausten yhteydessä tällä
   // parametrilla ja mallidatan yhteydessä toisella
-  if (paramFound == false && theId == kFmiDewPoint)
-    paramFound = theInfo->Param(kFmiDewPoint2M);
+  if (paramFound == false && theId == kFmiDewPoint) paramFound = theInfo->Param(kFmiDewPoint2M);
   return paramFound;
 }
 
@@ -753,10 +738,8 @@ void NFmiSoundingDataOpt1::DoAfterFillChecks(const boost::shared_ptr<NFmiFastQue
                                              FmiParameterName theId)
 {
   // jos ei nousevassa järjestyksessä, käännetään vektorissa olevat arvot
-  if (theInfo->HeightParamIsRising() == false)
-    std::reverse(data.begin(), data.end());
-  if (theId == kFmiPressure)
-    fPressureDataAvailable = true;
+  if (theInfo->HeightParamIsRising() == false) std::reverse(data.begin(), data.end());
+  if (theId == kFmiPressure) fPressureDataAvailable = true;
   if (theId == kFmiGeomHeight || theId == kFmiGeopHeight || theId == kFmiFlAltitude)
     fHeightDataAvailable = true;
 }
@@ -778,8 +761,7 @@ bool NFmiSoundingDataOpt1::FastFillParamData(const boost::shared_ptr<NFmiFastQue
   else if (theId == kFmiDewPoint && theInfo->Param(kFmiHumidity))
   {
     unsigned int RHindex = theInfo->ParamIndex();
-    if (!theInfo->Param(kFmiTemperature))
-      return false;
+    if (!theInfo->Param(kFmiTemperature)) return false;
     unsigned int Tindex = theInfo->ParamIndex();
     float T = 0;
     float RH = 0;
@@ -857,8 +839,7 @@ bool NFmiSoundingDataOpt1::FillParamData(const boost::shared_ptr<NFmiFastQueryIn
   else if (theId == kFmiDewPoint && theInfo->Param(kFmiHumidity))
   {
     unsigned int RHindex = theInfo->ParamIndex();
-    if (!theInfo->Param(kFmiTemperature))
-      return false;
+    if (!theInfo->Param(kFmiTemperature)) return false;
     unsigned int Tindex = theInfo->ParamIndex();
     float T = 0;
     float RH = 0;
@@ -903,8 +884,7 @@ unsigned long NFmiSoundingDataOpt1::GetHighestNonMissingValueLevelIndex(FmiParam
   std::deque<float>::size_type ssize = vec.size();
   unsigned long index = 0;
   for (unsigned long i = 0; i < ssize; i++)
-    if (vec[i] != kFloatMissing)
-      index = i;
+    if (vec[i] != kFloatMissing) index = i;
   return index;
 }
 
@@ -913,8 +893,7 @@ unsigned long NFmiSoundingDataOpt1::GetLowestNonMissingValueLevelIndex(FmiParame
   std::deque<float> &vec = GetParamData(theParaId);
   std::deque<float>::size_type ssize = vec.size();
   for (unsigned long i = 0; i < ssize; i++)
-    if (vec[i] != kFloatMissing)
-      return i;
+    if (vec[i] != kFloatMissing) return i;
   return gMissingIndex;
 }
 
@@ -934,17 +913,14 @@ bool NFmiSoundingDataOpt1::CheckForMissingLowLevelData(FmiParameterName theParaI
 bool NFmiSoundingDataOpt1::IsDataGood()
 {
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(kLCLCalcSurface, T, Td, P))
-    return false;
+  if (!GetValuesNeededInLCLCalculations(kLCLCalcSurface, T, Td, P)) return false;
 
   unsigned long missingIndexLimit =
       FmiRound(itsTemperatureData.size() * 0.2);  // jos viidesosa tärkeän parametrin ala alaosasta
                                                   // puuttuu, oletetaan että data on liian
                                                   // puutteellista ja kelvotonta
-  if (CheckForMissingLowLevelData(kFmiTemperature, missingIndexLimit))
-    return false;
-  if (CheckForMissingLowLevelData(kFmiDewPoint, missingIndexLimit))
-    return false;
+  if (CheckForMissingLowLevelData(kFmiTemperature, missingIndexLimit)) return false;
+  if (CheckForMissingLowLevelData(kFmiDewPoint, missingIndexLimit)) return false;
 
   return true;
 }
@@ -967,8 +943,7 @@ void NFmiSoundingDataOpt1::CutEmptyData(void)
   for (unsigned int i = 0; i < itsSoundingParameters.size(); i++)
   {
     unsigned int currentIndex = GetHighestNonMissingValueLevelIndex(itsSoundingParameters[i]);
-    if (currentIndex > greatestNonMissingLevelIndex)
-      greatestNonMissingLevelIndex = currentIndex;
+    if (currentIndex > greatestNonMissingLevelIndex) greatestNonMissingLevelIndex = currentIndex;
     if (greatestNonMissingLevelIndex >= maxLevelIndex)
       return;  // ei tarvitse leikata, kun dataa löytyy korkeimmaltakin leveliltä
   }
@@ -1119,8 +1094,7 @@ static bool AnyGoodValues(const std::deque<float> &values)
 {
   for (size_t i = 0; i < values.size(); i++)
   {
-    if (values[i] != kFloatMissing)
-      return true;
+    if (values[i] != kFloatMissing) return true;
   }
   return false;
 }
@@ -1132,11 +1106,9 @@ static bool AnyGoodValues(const std::deque<float> &values)
 void NFmiSoundingDataOpt1::SetVerticalParamStatus(void)
 {
   std::deque<float> &pVec = GetParamData(kFmiPressure);
-  if (::AnyGoodValues(pVec))
-    fPressureDataAvailable = true;
+  if (::AnyGoodValues(pVec)) fPressureDataAvailable = true;
   std::deque<float> &hVec = GetParamData(kFmiGeomHeight);
-  if (::AnyGoodValues(hVec))
-    fHeightDataAvailable = true;
+  if (::AnyGoodValues(hVec)) fHeightDataAvailable = true;
 }
 
 // theVec is vector that is to be erased from the start.
@@ -1401,8 +1373,7 @@ void NFmiSoundingDataOpt1::ClearDatas(void)
 
 bool NFmiSoundingDataOpt1::ModifyT2DryAdiapaticBelowGivenP(double P, double T)
 {
-  if (P == kFloatMissing || T == kFloatMissing)
-    return false;
+  if (P == kFloatMissing || T == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &tV = GetParamData(kFmiTemperature);
@@ -1429,8 +1400,7 @@ bool NFmiSoundingDataOpt1::ModifyT2DryAdiapaticBelowGivenP(double P, double T)
 
 bool NFmiSoundingDataOpt1::ModifyTd2MixingRatioBelowGivenP(double P, double T, double Td)
 {
-  if (P == kFloatMissing || Td == kFloatMissing)
-    return false;
+  if (P == kFloatMissing || Td == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &tV = GetParamData(kFmiTemperature);
@@ -1459,8 +1429,7 @@ bool NFmiSoundingDataOpt1::ModifyTd2MixingRatioBelowGivenP(double P, double T, d
 
 bool NFmiSoundingDataOpt1::ModifyTd2MoistAdiapaticBelowGivenP(double P, double Td)
 {
-  if (P == kFloatMissing || Td == kFloatMissing)
-    return false;
+  if (P == kFloatMissing || Td == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &tdV = GetParamData(kFmiDewPoint);
@@ -1502,10 +1471,8 @@ static float FixValuesWithLimits(float theValue, float minValue, float maxValue)
 {
   if (theValue != kFloatMissing)
   {
-    if (minValue != kFloatMissing)
-      theValue = FmiMax(theValue, minValue);
-    if (maxValue != kFloatMissing)
-      theValue = FmiMin(theValue, maxValue);
+    if (minValue != kFloatMissing) theValue = FmiMax(theValue, minValue);
+    if (maxValue != kFloatMissing) theValue = FmiMin(theValue, maxValue);
   }
   return theValue;
 }
@@ -1517,8 +1484,7 @@ bool NFmiSoundingDataOpt1::Add2ParamAtNearestP(float P,
                                                float maxValue,
                                                bool fCircularValue)
 {
-  if (P == kFloatMissing)
-    return false;
+  if (P == kFloatMissing) return false;
 
   std::deque<float> &pV = GetParamData(kFmiPressure);
   std::deque<float> &paramV = GetParamData(parId);
@@ -1541,8 +1507,7 @@ bool NFmiSoundingDataOpt1::Add2ParamAtNearestP(float P,
           closestIndex = i;
         }
       }
-      if (currentP < P && closestPdiff != kFloatMissing)
-        break;
+      if (currentP < P && closestPdiff != kFloatMissing) break;
     }
 
     if (closestPdiff != kFloatMissing)
@@ -1716,8 +1681,7 @@ double NFmiSoundingDataOpt1::CalcCTOTIndex(void)
 {
   double T500 = GetValueAtPressure(kFmiTemperature, 500);
   double TD850 = GetValueAtPressure(kFmiDewPoint, 850);
-  if (T500 != kFloatMissing && TD850 != kFloatMissing)
-    return (TD850 - T500);
+  if (T500 != kFloatMissing && TD850 != kFloatMissing) return (TD850 - T500);
   return kFloatMissing;
 }
 
@@ -1729,8 +1693,7 @@ double NFmiSoundingDataOpt1::CalcVTOTIndex(void)
 {
   double T500 = GetValueAtPressure(kFmiTemperature, 500);
   double T850 = GetValueAtPressure(kFmiTemperature, 850);
-  if (T500 != kFloatMissing && T850 != kFloatMissing)
-    return (T850 - T500);
+  if (T500 != kFloatMissing && T850 != kFloatMissing) return (T850 - T500);
   return kFloatMissing;
 }
 
@@ -1789,8 +1752,7 @@ double NFmiSoundingDataOpt1::CalcLCLPressureLevel(FmiLCLCalcType theLCLCalcType)
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   return NFmiSoundingFunctions::CalcLCLPressureFast(T, Td, P);
 }
@@ -1950,6 +1912,7 @@ class CapeAreaLfcData
   double EL(void) const { return itsEL; }
   bool LFConWarmerSide(void) const { return fLFConWarmerSide; }
   void LFConWarmerSide(bool newValue) { fLFConWarmerSide = newValue; }
+
  private:
   void CalcCapeAreaSize(void)
   {
@@ -2052,8 +2015,7 @@ double NFmiSoundingDataOpt1::CalcLFCIndex(FmiLCLCalcType theLCLCalcType, double 
 {
   double lfcIndexValue = kFloatMissing;
   // 1. Katso löytyykö valmiiksi lasketut arvot cachesta.
-  if (CheckLFCIndexCache(theLCLCalcType, lfcIndexValue, EL))
-    return lfcIndexValue;
+  if (CheckLFCIndexCache(theLCLCalcType, lfcIndexValue, EL)) return lfcIndexValue;
 
   // 2. Hae halutun laskentatavan (sur/500mix/mostUnstable) mukaiset T, Td ja P arvot.
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
@@ -2109,8 +2071,7 @@ double NFmiSoundingDataOpt1::CalcLFCIndex(FmiLCLCalcType theLCLCalcType, double 
       Diff_current = TLifted_current - T_current;
       if (NFmiQueryDataUtil::IsEqualEnough(Diff_current, 0., gUsedEpsilon))
         Diff_current = 0;  // linux vs windows - float vs double laskenta ero sovittelu yritys
-      if (processingLCLpoint && Diff_current > 0)
-        capeAreaData.LFConWarmerSide(true);
+      if (processingLCLpoint && Diff_current > 0) capeAreaData.LFConWarmerSide(true);
 
       if (firstLevel && Diff_current > 0)
       {  // Jos on heti 'pinta' CAPE alue, sille pitää tehdä erillinen hanskaus
@@ -2172,12 +2133,10 @@ double NFmiSoundingDataOpt1::CalcCAPE500Index(FmiLCLCalcType theLCLCalcType, dou
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   // HUOM! Pitää ottaa huomioon aseman korkeus kun tehdään laskuja!!!!
-  if (theHeightLimit != kFloatMissing)
-    theHeightLimit += ZeroHeight();
+  if (theHeightLimit != kFloatMissing) theHeightLimit += ZeroHeight();
 
   std::deque<float> &pValues = GetParamData(kFmiPressure);
   std::deque<float> &tValues = GetParamData(kFmiTemperature);
@@ -2227,8 +2186,7 @@ double NFmiSoundingDataOpt1::CalcCAPE_TT_Index(FmiLCLCalcType theLCLCalcType,
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   std::deque<float> &pValues = GetParamData(kFmiPressure);
   std::deque<float> &tValues = GetParamData(kFmiTemperature);
@@ -2275,8 +2233,7 @@ double NFmiSoundingDataOpt1::CalcCINIndex(FmiLCLCalcType theLCLCalcType)
 {
   // 1. calc T,Td,P values from 500 m layer avg or surface values
   double T = kFloatMissing, Td = kFloatMissing, P = kFloatMissing;
-  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P))
-    return kFloatMissing;
+  if (!GetValuesNeededInLCLCalculations(theLCLCalcType, T, Td, P)) return kFloatMissing;
 
   std::deque<float> &pValues = GetParamData(kFmiPressure);
   std::deque<float> &tValues = GetParamData(kFmiTemperature);
@@ -2319,8 +2276,7 @@ double NFmiSoundingDataOpt1::CalcCINIndex(FmiLCLCalcType theLCLCalcType)
       }
     }
   }
-  if (!(firstCinLayerFound && capeLayerFoundAfterCin))
-    CIN = 0;
+  if (!(firstCinLayerFound && capeLayerFoundAfterCin)) CIN = 0;
   return CIN;
 }
 
@@ -2337,8 +2293,7 @@ double NFmiSoundingDataOpt1::CalcWindBulkShearComponent(double startH,
   float startValue = GetValueAtHeight(theParId, static_cast<float>(startH * 1000));
   float endValue = GetValueAtHeight(theParId, static_cast<float>(endH * 1000));
   float shearComponent = endValue - startValue;
-  if (endValue == kFloatMissing || startValue == kFloatMissing)
-    shearComponent = kFloatMissing;
+  if (endValue == kFloatMissing || startValue == kFloatMissing) shearComponent = kFloatMissing;
   return shearComponent;
 }
 
@@ -2362,8 +2317,7 @@ double NFmiSoundingDataOpt1::CalcThetaEDiffIndex(double startH, double endH)
   if (endT == kFloatMissing || endTd == kFloatMissing || endP == kFloatMissing)
     return kFloatMissing;
   double endThetaE = NFmiSoundingFunctions::CalcThetaE(endT, endTd, endP);
-  if (startThetaE == kFloatMissing || endThetaE == kFloatMissing)
-    return kFloatMissing;
+  if (startThetaE == kFloatMissing || endThetaE == kFloatMissing) return kFloatMissing;
   double diffValue = startThetaE - endThetaE;
   return diffValue;
 }
@@ -2376,8 +2330,7 @@ double NFmiSoundingDataOpt1::CalcBulkShearIndex(double startH, double endH)
   double uTot = CalcWindBulkShearComponent(startH, endH, kFmiWindUMS);
   double vTot = CalcWindBulkShearComponent(startH, endH, kFmiWindVMS);
   double BS = ::sqrt(uTot * uTot + vTot * vTot);
-  if (uTot == kFloatMissing || vTot == kFloatMissing)
-    BS = kFloatMissing;
+  if (uTot == kFloatMissing || vTot == kFloatMissing) BS = kFloatMissing;
   return BS;
 }
 
@@ -2415,11 +2368,11 @@ v_ID = v0_6 - shr_0_6_u_n * 7.5;
 (7.5 are meters per second... watch out when you work with knots instead)
 
 */  // **********
-                                                                                    // SRH
-                                                                                    // calculation
-                                                                                    // help from
-                                                                                    // Pieter
-                                                                                    // Groenemeijer
+    // SRH
+    // calculation
+    // help from
+    // Pieter
+    // Groenemeijer
 // ******************
 
 // I use same variable names as with the Pieters help evem though calculations are not
@@ -2591,8 +2544,7 @@ double NFmiSoundingDataOpt1::CalcTOfLiftedAirParcel(double T, double Td, double 
 {
   std::string cacheKeyStr = MakeCacheString(T, Td, fromP, toP);
   LiftedAirParcelCacheType::iterator it = itsLiftedAirParcelCache.find(cacheKeyStr);
-  if (it != itsLiftedAirParcelCache.end())
-    return it->second;  // palautetaan arvo cachesta
+  if (it != itsLiftedAirParcelCache.end()) return it->second;  // palautetaan arvo cachesta
 
   double Tparcel = kFloatMissing;
   // 1. laske LCL kerroksen paine alkaen fromP:stä

--- a/smarttools/NFmiSoundingDataOpt1.h
+++ b/smarttools/NFmiSoundingDataOpt1.h
@@ -11,8 +11,8 @@
 
 #include "NFmiSoundingData.h"
 
-#include <newbase/NFmiMetTime.h>
 #include <newbase/NFmiLocation.h>
+#include <newbase/NFmiMetTime.h>
 #include <newbase/NFmiParameterName.h>
 #include <newbase/NFmiQueryDataUtil.h>
 
@@ -225,4 +225,3 @@ class NFmiSoundingDataOpt1
   typedef std::unordered_map<std::string, double> LiftedAirParcelCacheType;
   LiftedAirParcelCacheType itsLiftedAirParcelCache;
 };
-

--- a/smarttools/NFmiSoundingFunctions.cpp
+++ b/smarttools/NFmiSoundingFunctions.cpp
@@ -9,8 +9,8 @@
 
 #include "NFmiSoundingFunctions.h"
 #include <newbase/NFmiAngle.h>
-#include <newbase/NFmiValueString.h>
 #include <newbase/NFmiInterpolation.h>
+#include <newbase/NFmiValueString.h>
 
 namespace NFmiSoundingFunctions
 {
@@ -78,8 +78,7 @@ double WMR(double T, double P)
 double ESAT(double T)  // T kelvineinä tai celsiuksina
 {
   double T0 = 0.;
-  if (T < 105.)
-    T0 = 273.15;
+  if (T < 105.) T0 = 273.15;
 
   // Formula with T = temperature in K
   //   esat = exp( -6763.6/(T+T0) - 4.9283*alog((T+T0)) + 54.2190 )
@@ -221,8 +220,7 @@ double TSA(double OS, double P)
     D = D / 2.;
     double X = A * ::exp(-2.6518986 * MIXR_SAT(TQ, P) / TQ) - TQ * (::pow((1000. / P), .286));
     //;  IF THE TEMPERATURE DIFFERENCE, X, IS SMALL, EXIT THIS LOOP.
-    if (::fabs(X) < 0.01)
-      break;
+    if (::fabs(X) < 0.01) break;
     D = (X < 0) ? -fabs(D) : fabs(D);  // hämärää koodia alkuperäisessä kielessä
     TQ = TQ + D;
   }
@@ -383,8 +381,7 @@ double CalcLCLPressure(double T, double Td, double P)
     double Tw = TMR(w, currentP);
     double Tdry = Tpot2t(tpot, currentP);
 
-    if (Tdry < Tw)
-      break;
+    if (Tdry < Tw) break;
     lastP = currentP;  // viimeisinta painetta ennen kuin Tw ja Tdry ovat leikanneet, voidaan
                        // käyttää tarkemman LCL painepinnan interpolointiin
   }
@@ -428,8 +425,7 @@ double CalcLCLPressureFast(double T, double Td, double P)
   {
     iterationCount++;
     currentP = IterateMixMoistDiffWithNewtonMethod(w, tpot, currentP, diff);
-    if (::fabs(diff) < 0.01)
-      break;
+    if (::fabs(diff) < 0.01) break;
     if (currentP < 100)  // most unstable tapauksissa etsintä piste saattaa pompata tosi ylös
     {  // tässä on paineen arvoksi tullut niin pieni että nostetaan sitä takaisin ylös ja jatketaan
       // etsintöjä

--- a/smarttools/NFmiSoundingFunctions.h
+++ b/smarttools/NFmiSoundingFunctions.h
@@ -44,8 +44,7 @@ float CalcLogInterpolatedWindWectorValue(float x1, float x2, float x, float wv1,
 template <typename T>
 bool IsEqualEnough(T value1, T value2, T usedEpsilon)
 {
-  if (::fabs(static_cast<double>(value1 - value2)) < usedEpsilon)
-    return true;
+  if (::fabs(static_cast<double>(value1 - value2)) < usedEpsilon) return true;
   return false;
 }
 
@@ -62,4 +61,3 @@ MyPoint CalcTwoLineIntersectionPoint(const MyPoint &P1,
                                      const MyPoint &P3,
                                      const MyPoint &P4);
 }
-

--- a/smarttools/NFmiSoundingIndexCalculator.cpp
+++ b/smarttools/NFmiSoundingIndexCalculator.cpp
@@ -7,12 +7,12 @@
  */
 // ======================================================================
 
+#include "NFmiSoundingIndexCalculator.h"
 #include "NFmiDrawParam.h"
 #include "NFmiInfoOrganizer.h"
 #include "NFmiSoundingData.h"
 #include "NFmiSoundingDataOpt1.h"
 #include "NFmiSoundingFunctions.h"
-#include "NFmiSoundingIndexCalculator.h"
 #include <newbase/NFmiFastQueryInfo.h>
 #include <newbase/NFmiGrid.h>
 #include <newbase/NFmiQueryData.h>
@@ -149,8 +149,7 @@ static bool FillSurfaceValuesFromInfo(NFmiSmartInfo *theInfo, NFmiSoundingData &
 
 static void CheckIfStopped(NFmiStopFunctor *theStopFunctor)
 {
-  if (theStopFunctor && theStopFunctor->Stop())
-    throw NFmiStopThreadException();
+  if (theStopFunctor && theStopFunctor->Stop()) throw NFmiStopThreadException();
 }
 
 static void CalcAllSoundingIndexParamFields(boost::shared_ptr<NFmiFastQueryInfo> &theSourceInfo,
@@ -168,8 +167,7 @@ static void CalcAllSoundingIndexParamFields(boost::shared_ptr<NFmiFastQueryInfo>
     try
     {
       // bool surfaceBaseStatus = false;
-      if (useFastFill)
-        theSourceInfo->LocationIndex(theResultInfo->LocationIndex());
+      if (useFastFill) theSourceInfo->LocationIndex(theResultInfo->LocationIndex());
       ::FillSoundingDataOpt1(theSourceInfo,
                              soundingDataOpt1,
                              theResultInfo->Time(),
@@ -253,8 +251,8 @@ static void CalculatePartOfSoundingData(boost::shared_ptr<NFmiFastQueryInfo> &th
   {
     // lopetetaan muutenkin, jos tulee poikkeus
     if (fDoCerrReporting)
-      std::cerr << "thread nro: " << index << " stops because exception was thrown:\n" << e.what()
-                << std::endl;
+      std::cerr << "thread nro: " << index << " stops because exception was thrown:\n"
+                << e.what() << std::endl;
   }
   catch (...)
   {
@@ -262,8 +260,7 @@ static void CalculatePartOfSoundingData(boost::shared_ptr<NFmiFastQueryInfo> &th
     if (fDoCerrReporting)
       std::cerr << "thread nro: " << index << " stops because unknown error." << std::endl;
   }
-  if (fDoCerrReporting)
-    std::cerr << "thread nro: " << index << " end here." << std::endl;
+  if (fDoCerrReporting) std::cerr << "thread nro: " << index << " end here." << std::endl;
 }
 
 static void CalculateSoundingDataOneTimeStepAtTime(
@@ -310,8 +307,8 @@ static void CalculateSoundingDataOneTimeStepAtTime(
   {
     // lopetetaan muutenkin, jos tulee poikkeus
     if (fDoCerrReporting)
-      std::cerr << "thread nro: " << index << " stops because exception was thrown:\n" << e.what()
-                << std::endl;
+      std::cerr << "thread nro: " << index << " stops because exception was thrown:\n"
+                << e.what() << std::endl;
   }
   catch (...)
   {
@@ -319,8 +316,7 @@ static void CalculateSoundingDataOneTimeStepAtTime(
     if (fDoCerrReporting)
       std::cerr << "thread nro: " << index << " stops because unknown error." << std::endl;
   }
-  if (fDoCerrReporting)
-    std::cerr << "thread nro: " << index << " end here." << std::endl;
+  if (fDoCerrReporting) std::cerr << "thread nro: " << index << " end here." << std::endl;
 }
 
 // Jos useFastFill on true, on datoilla sama hila ja aika descriptor rakenne
@@ -354,8 +350,7 @@ void NFmiSoundingIndexCalculator::CalculateWholeSoundingData(NFmiQueryData &theS
   if (fUseOnlyOneThread || usedThreadCount < 2)
   {  // jos aikoja oli alle kaksi, lasketaan data yhdessä funktiossa
 
-    if (fDoCerrReporting)
-      std::cerr << "making data in single thread" << std::endl;
+    if (fDoCerrReporting) std::cerr << "making data in single thread" << std::endl;
     boost::shared_ptr<NFmiFastQueryInfo> sourceInfo(new NFmiFastQueryInfo(&theSourceData));
     boost::shared_ptr<NFmiFastQueryInfo> resultInfo(new NFmiFastQueryInfo(&theResultData));
     ::CalculatePartOfSoundingData(
@@ -363,8 +358,7 @@ void NFmiSoundingIndexCalculator::CalculateWholeSoundingData(NFmiQueryData &theS
   }
   else
   {
-    if (fDoCerrReporting)
-      std::cerr << "making data in multiple threads" << std::endl;
+    if (fDoCerrReporting) std::cerr << "making data in multiple threads" << std::endl;
 
     theSourceData.LatLonCache();  // Ennen multi-thread laskuja pitää varmistaa että kunkin datan
                                   // (source + result) latlon-cache on alustettu, muutern tulee
@@ -393,8 +387,7 @@ void NFmiSoundingIndexCalculator::CalculateWholeSoundingData(NFmiQueryData &theS
                                              fDoCerrReporting));
     calcParts.join_all();  // odotetaan että threadit lopettavat
 
-    if (fDoCerrReporting)
-      std::cerr << "all threads ended" << std::endl;
+    if (fDoCerrReporting) std::cerr << "all threads ended" << std::endl;
   }
 }
 
@@ -1167,8 +1160,7 @@ boost::shared_ptr<NFmiQueryData> NFmiSoundingIndexCalculator::CreateNewSoundingI
     throw std::runtime_error("Error in CreateNewSoundingIndexData, cannot read source data.");
   else
   {
-    if (fDoCerrReporting)
-      std::cerr << "read qd-file: " << theSourceFileFilter << std::endl;
+    if (fDoCerrReporting) std::cerr << "read qd-file: " << theSourceFileFilter << std::endl;
   }
 
   return NFmiSoundingIndexCalculator::CreateNewSoundingIndexData(sourceData,

--- a/smarttools/NFmiSoundingIndexCalculator.h
+++ b/smarttools/NFmiSoundingIndexCalculator.h
@@ -27,8 +27,7 @@ class NFmiStopFunctor;
 // Sitä varten tein oman parametrilistan, joka kuuluisi NFmiParameterName-enumiin.
 // Mutta en halua sotkea sitä näillä, joten tein oman listan, jota kuitenkin käytetään
 // kuin se olisi originaali NFmiParameterName-enumissa.
-typedef enum
-{
+typedef enum {
   kSoundingParNone =
       4619,  // aloitan luvut jostain numerosta mikä ei mene sekaisin originaali param-listan kanssa
   // aluksi surface (sur) arvojen avulla lasketut parametrit
@@ -133,4 +132,3 @@ class NFmiSoundingIndexCalculator
       bool fUseOnlyOneThread = true,
       int theMaxThreadCount = 0);
 };
-

--- a/smarttools/NFmiStation2GridMask.cpp
+++ b/smarttools/NFmiStation2GridMask.cpp
@@ -26,9 +26,7 @@ NFmiStation2GridMask::NFmiStation2GridMask(Type theMaskType,
 {
 }
 
-NFmiStation2GridMask::~NFmiStation2GridMask(void)
-{
-}
+NFmiStation2GridMask::~NFmiStation2GridMask(void) {}
 
 NFmiStation2GridMask::NFmiStation2GridMask(const NFmiStation2GridMask &theOther)
     : NFmiInfoAreaMask(theOther),
@@ -44,10 +42,7 @@ NFmiStation2GridMask::NFmiStation2GridMask(const NFmiStation2GridMask &theOther)
 {
 }
 
-NFmiAreaMask *NFmiStation2GridMask::Clone(void) const
-{
-  return new NFmiStation2GridMask(*this);
-}
+NFmiAreaMask *NFmiStation2GridMask::Clone(void) const { return new NFmiStation2GridMask(*this); }
 
 double NFmiStation2GridMask::Value(const NFmiCalculationParams &theCalculationParams,
                                    bool /* fUseTimeInterpolationAlways */)
@@ -139,9 +134,7 @@ NFmiNearestObsValue2GridMask::NFmiNearestObsValue2GridMask(
   itsFunctionArgumentCount = theArgumentCount;
 }
 
-NFmiNearestObsValue2GridMask::~NFmiNearestObsValue2GridMask(void)
-{
-}
+NFmiNearestObsValue2GridMask::~NFmiNearestObsValue2GridMask(void) {}
 
 NFmiNearestObsValue2GridMask::NFmiNearestObsValue2GridMask(
     const NFmiNearestObsValue2GridMask &theOther)

--- a/smarttools/NFmiTEMPCode.cpp
+++ b/smarttools/NFmiTEMPCode.cpp
@@ -1,7 +1,7 @@
 
+#include "NFmiTEMPCode.h"
 #include "NFmiAviationStationInfoSystem.h"
 #include "NFmiDictionaryFunction.h"
-#include "NFmiTEMPCode.h"
 #include <newbase/NFmiFastQueryInfo.h>
 #include <newbase/NFmiLocationBag.h>
 #include <newbase/NFmiQueryDataUtil.h>
@@ -40,9 +40,7 @@ NFmiTEMPCode::NFmiTEMPCode(NFmiAviationStationInfoSystem *theTempStations,
 {
 }
 
-NFmiTEMPCode::~NFmiTEMPCode(void)
-{
-}
+NFmiTEMPCode::~NFmiTEMPCode(void) {}
 
 void NFmiTEMPCode::Clear(void)
 {
@@ -66,8 +64,7 @@ static void InsertLevelData(std::map<double, TEMPLevelData> &theLevelMap,
 void NFmiTEMPCode::ForceWantedPressureLevels(NFmiVPlaceDescriptor &theLevels)
 {
   size_t levelSize = itsLevels.size();
-  if (levelSize <= 2)
-    return;
+  if (levelSize <= 2) return;
   theLevels.Reset();
   theLevels.Next();
   double currentMainLevel = static_cast<double>(theLevels.Level()->LevelValue());
@@ -103,8 +100,7 @@ void NFmiTEMPCode::ForceWantedPressureLevels(NFmiVPlaceDescriptor &theLevels)
        // level, mikä ei ole molempien yläpuolella
       do
       {
-        if (theLevels.Next() == false)
-          break;
+        if (theLevels.Next() == false) break;
         currentMainLevel = static_cast<double>(theLevels.Level()->LevelValue());
       } while (p1 < currentMainLevel && p2 < currentMainLevel);
     }
@@ -195,8 +191,7 @@ int NFmiTEMPCode::InsertCodeStrings(const std::string &theCodeAStr,
                                     bool fNoEqualSignInCode)
 {
   std::string ttStr;
-  if (fNoEqualSignInCode)
-    ttStr = "TT";
+  if (fNoEqualSignInCode) ttStr = "TT";
   itsOriginalCodeAStr = ttStr + theCodeAStr;
   itsOriginalCodeBStr = ttStr + theCodeBStr;
   itsOriginalCodeCStr = ttStr + theCodeCStr;
@@ -247,8 +242,7 @@ static bool GetTandTd(const std::string &theTnTnTanDnDn_str, double &T, double &
 {
   T = kFloatMissing;
   Td = kFloatMissing;
-  if (theTnTnTanDnDn_str == "/////")
-    return true;  // ok, palautetaan puuttuvat arvot
+  if (theTnTnTanDnDn_str == "/////") return true;  // ok, palautetaan puuttuvat arvot
 
   std::string TnTn_str(theTnTnTanDnDn_str.begin(), theTnTnTanDnDn_str.begin() + 2);
   double TintPart = ::GetValue<double>(TnTn_str);
@@ -282,8 +276,7 @@ static bool GetWDandWS(const std::string &thedddff_Str, double &WD, double &WS, 
 {
   WD = kFloatMissing;
   WS = kFloatMissing;
-  if (thedddff_Str == "/////")
-    return true;  // ok, palautetaan puuttuvat arvot
+  if (thedddff_Str == "/////") return true;  // ok, palautetaan puuttuvat arvot
 
   // HUOM! jos tuulen suunta tai nopeus puuttuu, niitä voisi hanskata paremmin ja laskea toisen
   // vaikka
@@ -291,12 +284,10 @@ static bool GetWDandWS(const std::string &thedddff_Str, double &WD, double &WS, 
   // piirretyksi)
   std::string ddd_str(thedddff_Str.begin(), thedddff_Str.begin() + 3);
   int WDtmp = static_cast<int>(kFloatMissing);
-  if (ddd_str.find('/') == std::string::npos)
-    WDtmp = ::GetValue<int>(ddd_str);
+  if (ddd_str.find('/') == std::string::npos) WDtmp = ::GetValue<int>(ddd_str);
   std::string ff_str(thedddff_Str.begin() + 3, thedddff_Str.begin() + 5);
   double WStmp = kFloatMissing;
-  if (ff_str.find('/') == std::string::npos)
-    WStmp = ::GetValue<double>(ff_str);
+  if (ff_str.find('/') == std::string::npos) WStmp = ::GetValue<double>(ff_str);
 
   if (WDtmp != kFloatMissing && WStmp != kFloatMissing)
   {
@@ -310,8 +301,7 @@ static bool GetWDandWS(const std::string &thedddff_Str, double &WD, double &WS, 
       WD = WDtmp - 1;
       WS = (WStmp + 100) / 2;  // kt -> m/s konversio nyt jaetaan 2:lla!!!!!
     }
-    if (fConvertKt2Ms)
-      WS = WS / 2.0;  // 1.94384; // muunnetaan solmut -> m/s
+    if (fConvertKt2Ms) WS = WS / 2.0;  // 1.94384; // muunnetaan solmut -> m/s
   }
 
   return true;
@@ -389,8 +379,7 @@ static bool GetPandH(const std::string &thePPhhh_Str, double &P, double &h)
   std::string hhh_str(thePPhhh_Str.begin() + 2, thePPhhh_Str.begin() + 5);
   double hhhtmp = ::GetValue<double>(hhh_str);
 
-  if (PPtmp != kFloatMissing)
-    P = ::GetMainPressureLevel(static_cast<int>(PPtmp));
+  if (PPtmp != kFloatMissing) P = ::GetMainPressureLevel(static_cast<int>(PPtmp));
   if (P != kFloatMissing && hhhtmp != kFloatMissing)
     h = ::GetMainPressureHeight(static_cast<int>(PPtmp), static_cast<int>(hhhtmp));
 
@@ -437,8 +426,7 @@ static bool DecodeHeader(std::stringstream &ssin,
       ssin >> MiMiMjMj_Str;  // joskus voi olla esim. RRB sana ennen TTxx -stringiä, tällöin vain
                              // luetaan seuraava sana
   }
-  if (MiMiMjMj_Str.size() != 4)
-    return false;
+  if (MiMiMjMj_Str.size() != 4) return false;
   bool doTempMobil = false;  // jos false, normaali TEMP, muuten TEMP MOBIL
   bool doShip = false;  // jos false, normaali TEMP, muuten TEMP MOBIL, joka on aseman korkeus info
                         // muuten sama kuin MOBIL
@@ -456,8 +444,7 @@ static bool DecodeHeader(std::stringstream &ssin,
     fTempMobil = doTempMobil;  // A-osiossa vain talletetaan onko mobiili temp kyseessä
   else
   {  // tarkistetaan että sama temp tyyppi, kuin A-osiossa ollut
-    if (fTempMobil != doTempMobil)
-      return false;  // pitäisi heittää poikkeus!!
+    if (fTempMobil != doTempMobil) return false;  // pitäisi heittää poikkeus!!
   }
 
   if (::toupper(MiMiMjMj_Str[2]) == theWantedSectionChar &&
@@ -471,8 +458,7 @@ static bool DecodeHeader(std::stringstream &ssin,
     }
     std::string YYGGId_Str;  // esim. "64022"
     ssin >> YYGGId_Str;
-    if (YYGGId_Str.size() != 5)
-      return false;
+    if (YYGGId_Str.size() != 5) return false;
     std::string dayStr(YYGGId_Str.begin(), YYGGId_Str.begin() + 2);
     short day = NFmiStringTools::Convert<short>(dayStr);
     if (day > 50)
@@ -501,9 +487,8 @@ static bool DecodeHeader(std::stringstream &ssin,
     if (fInitializeValues)
       theTime = tempTime;  // A-osiossa vain talletetaan aika
     else
-    {  // tarkistetaan että sama aika, kuin A-osiossa ollut
-      if (theTime != tempTime)
-        return false;  // pitäisi heittää poikkeus!!
+    {                                         // tarkistetaan että sama aika, kuin A-osiossa ollut
+      if (theTime != tempTime) return false;  // pitäisi heittää poikkeus!!
     }
 
     if (doTempMobil)
@@ -511,8 +496,7 @@ static bool DecodeHeader(std::stringstream &ssin,
       std::string _99LaLaLa_Str;  // esim. "99613" // muuttujassa alaviiva alku, koska numero ei voi
                                   // aloittaa muuttujaa
       ssin >> _99LaLaLa_Str;
-      if (_99LaLaLa_Str.size() != 5)
-        return false;
+      if (_99LaLaLa_Str.size() != 5) return false;
       double lat = NFmiStringTools::Convert<double>(
           std::string(_99LaLaLa_Str.begin() + 2, _99LaLaLa_Str.begin() + 4));
       double latTenth = NFmiStringTools::Convert<double>(
@@ -521,8 +505,7 @@ static bool DecodeHeader(std::stringstream &ssin,
       lat += latTenth;
       std::string QcLoLoLoLo_Str;  // esim. "10280"
       ssin >> QcLoLoLoLo_Str;
-      if (QcLoLoLoLo_Str.size() != 5)
-        return false;
+      if (QcLoLoLoLo_Str.size() != 5) return false;
       double lon = NFmiStringTools::Convert<double>(
           std::string(QcLoLoLoLo_Str.begin() + 1, QcLoLoLoLo_Str.begin() + 4));
       double lonTenth = NFmiStringTools::Convert<double>(
@@ -544,8 +527,7 @@ static bool DecodeHeader(std::stringstream &ssin,
       std::string IIiii_Str;  // IIiii asematunnuskoodi esim. "02963" II on alue koodi ja 963 on
                               // asema tunnus
       ssin >> IIiii_Str;
-      if (IIiii_Str.size() != 5)
-        return false;
+      if (IIiii_Str.size() != 5) return false;
 
       // HUOM! tässä pitäisi olla joku asema tietokanta käytössä, mistä saisi aseman sijainnin
       unsigned long stationId = NFmiStringTools::Convert<unsigned long>(IIiii_Str);
@@ -570,8 +552,7 @@ static bool DecodeHeader(std::stringstream &ssin,
       theStation = station;  // A-osiossa vain talletetaan aika
     else
     {  // tarkistetaan että sama asema, kuin A-osiossa ollut
-      if (theStation != station)
-        return false;  // pitäisi heittää poikkeus!!
+      if (theStation != station) return false;  // pitäisi heittää poikkeus!!
     }
     return true;
   }
@@ -599,21 +580,17 @@ bool NFmiTEMPCode::DecodeA(void)
       std::string TTTaDD_Str;
       std::string dddff_Str;
       ssin >> _99PPP_Str;
-      if (_99PPP_Str.size() != 5)
-        return false;
+      if (_99PPP_Str.size() != 5) return false;
       ssin >> TTTaDD_Str;
-      if (TTTaDD_Str.size() != 5)
-        return false;
+      if (TTTaDD_Str.size() != 5) return false;
       ssin >> dddff_Str;
-      if (dddff_Str.size() != 5)
-        return false;
+      if (dddff_Str.size() != 5) return false;
       if (std::string(_99PPP_Str.begin(), _99PPP_Str.begin() + 2) ==
           "99")  // tarkistetaan että 99-taikasana löytyy
       {
         double surfPressure = NFmiStringTools::Convert<double>(
             std::string(_99PPP_Str.begin() + 2, _99PPP_Str.begin() + 5));
-        if (surfPressure < 100.)
-          surfPressure += 1000.;
+        if (surfPressure < 100.) surfPressure += 1000.;
         double T = kFloatMissing;
         double Td = kFloatMissing;
         bool status = ::GetTandTd(TTTaDD_Str, T, Td);
@@ -645,8 +622,7 @@ bool NFmiTEMPCode::DecodeA(void)
           WD = kFloatMissing;
           WS = kFloatMissing;
 
-          if (PnPnhnhnhn_Str.size() != 5)
-            return false;
+          if (PnPnhnhnhn_Str.size() != 5) return false;
           if (PnPnhnhnhn_Str == "77999")
             break;  // nyt tultiin loppuun, ei ole tietoa max tuuli jutuista
           else if (PnPnhnhnhn_Str == "88999")
@@ -684,11 +660,9 @@ bool NFmiTEMPCode::DecodeA(void)
             ssin >> dddff_Str;
           }
 
-          if (TTTaDD_Str.size() != 5)
-            return false;
+          if (TTTaDD_Str.size() != 5) return false;
           //					ssin >> dddff_Str;
-          if (dddff_Str.size() != 5)
-            return false;
+          if (dddff_Str.size() != 5) return false;
 
           // TÄMÄ erikois kerroksien tarkastelu menee ihan pieleen
           status &= ::GetPandH(PnPnhnhnhn_Str, P, h);
@@ -705,8 +679,7 @@ bool NFmiTEMPCode::DecodeA(void)
           AddData(levelData);  // laitetaan saatu leveli talteen
 
           ssin >> PnPnhnhnhn_Str;  // tämä pitää lukea lopuksi, koska loopin lopetus riippuu tästä
-          if (ssin.good() == false)
-            break;
+          if (ssin.good() == false) break;
           // throw std::runtime_error("Data tiedostossa loppui kesken.");
           PnPn_Str = std::string(PnPnhnhnhn_Str.begin(), PnPnhnhnhn_Str.begin() + 2);
         }
@@ -754,12 +727,9 @@ bool NFmiTEMPCode::DecodeB(void)
         double Td = kFloatMissing;
 
         ssin >> XXPPP_Str;
-        if (XXPPP_Str.size() != 5)
-          return false;
-        if (XXPPP_Str == "21212")
-          break;  // nyt tultiin tämän osion loppuun
-        if (XXPPP_Str == "31313")
-          break;  // nyt tultiin tämän osion loppuun
+        if (XXPPP_Str.size() != 5) return false;
+        if (XXPPP_Str == "21212") break;  // nyt tultiin tämän osion loppuun
+        if (XXPPP_Str == "31313") break;  // nyt tultiin tämän osion loppuun
         if (XXPPP_Str == "41414")
         {
           _41414_groupMissing =
@@ -772,11 +742,9 @@ bool NFmiTEMPCode::DecodeB(void)
           // paine jää puuttuvaksi ja kaikki tämän levelin arvot jäävät
           // taltioimatta
           P = NFmiStringTools::Convert<double>(PPP_partStr);
-        if (P < 50.)
-          P += 1000.;
+        if (P < 50.) P += 1000.;
         ssin >> TTTaDD_Str;
-        if (TTTaDD_Str.size() != 5)
-          return false;
+        if (TTTaDD_Str.size() != 5) return false;
         status &= ::GetTandTd(TTTaDD_Str, T, Td);
 
         levelData.Clear();
@@ -799,11 +767,9 @@ bool NFmiTEMPCode::DecodeB(void)
             double WS = kFloatMissing;
 
             ssin >> XXPPP_Str;
-            if (XXPPP_Str.size() != 5)
-              return false;
-            if (XXPPP_Str == "41414")
-              break;                   // nyt tultiin tämän osion loppuun
-            if (XXPPP_Str == "51515")  // joskus 51515 tulee ilman 41414:ää
+            if (XXPPP_Str.size() != 5) return false;
+            if (XXPPP_Str == "41414") break;  // nyt tultiin tämän osion loppuun
+            if (XXPPP_Str == "51515")         // joskus 51515 tulee ilman 41414:ää
             {
               _41414_groupMissing = true;
               break;  // nyt tultiin tämän osion loppuun
@@ -819,11 +785,9 @@ bool NFmiTEMPCode::DecodeB(void)
 
             P = NFmiStringTools::Convert<double>(
                 std::string(XXPPP_Str.begin() + 2, XXPPP_Str.begin() + 5));
-            if (P < 50.)
-              P += 1000.;
+            if (P < 50.) P += 1000.;
             ssin >> dddff_Str;
-            if (dddff_Str.size() != 5)
-              return false;
+            if (dddff_Str.size() != 5) return false;
             status &= ::GetWDandWS(dddff_Str, WD, WS, fConvertKt2Ms);
 
             levelData.Clear();
@@ -907,8 +871,7 @@ struct LevelSorter
   bool operator()(const TEMPLevelData &theLevel1, const TEMPLevelData &theLevel2)
   {
     if (theLevel1.itsPressure != kFloatMissing && theLevel2.itsPressure != kFloatMissing)
-      if (theLevel1.itsPressure < theLevel2.itsPressure)
-        return true;
+      if (theLevel1.itsPressure < theLevel2.itsPressure) return true;
     return false;
   }
 };
@@ -1122,8 +1085,7 @@ NFmiQueryData *DecodeTEMP::MakeNewDataFromTEMPStr(const std::string &theTEMPStr,
             codeParcels[i], codeParcels[i + 1], "", "", noEqualSignInCode);
       else if (codeParcels.size() - i == 1)
         decodeCount = tempCode.InsertCodeStrings(codeParcels[i], "", "", "", noEqualSignInCode);
-      if (decodeCount != 4)
-        errorCount++;
+      if (decodeCount != 4) errorCount++;
     }
     catch (std::exception & /* e */)
     {

--- a/smarttools/NFmiTEMPCode.h
+++ b/smarttools/NFmiTEMPCode.h
@@ -4,8 +4,8 @@
 #include <newbase/NFmiMetTime.h>
 #include <newbase/NFmiStation.h>
 
-#include <vector>
 #include <map>
+#include <vector>
 
 class NFmiQueryData;
 class NFmiAviationStationInfoSystem;
@@ -77,6 +77,7 @@ class NFmiTEMPCode
   const NFmiStation &Station(void) const { return itsStation; }
   void Station(const NFmiStation &theStation) { itsStation = theStation; }
   const std::map<double, TEMPLevelData> &LevelData(void) const { return itsLevels; }
+
  private:
   int Decode(void);
   bool DecodeA(void);
@@ -98,4 +99,3 @@ class NFmiTEMPCode
 
   std::map<double, TEMPLevelData> itsLevels;
 };
-

--- a/smarttools/NFmiUndoRedoQData.cpp
+++ b/smarttools/NFmiUndoRedoQData.cpp
@@ -19,8 +19,7 @@ NFmiUndoRedoQData::~NFmiUndoRedoQData(void)
   {
     for (int level = 0; level < (*itsMaxUndoLevelPtr); level++)
     {
-      if (itsUndoTable[level])
-        delete itsUndoTable[level];
+      if (itsUndoTable[level]) delete itsUndoTable[level];
     }
   }
   if (itsUndoTable)
@@ -71,16 +70,12 @@ bool NFmiUndoRedoQData::SnapShotData(
     const NFmiHarmonizerBookKeepingData &theHarmonizerBookKeepingData,
     const NFmiRawData &theRawData)
 {
-  if (itsCurrentUndoLevelPtr == 0)
-    return false;
-  if (!itsUndoTable || !itsUndoTextTable)
-    return false;
+  if (itsCurrentUndoLevelPtr == 0) return false;
+  if (!itsUndoTable || !itsUndoTextTable) return false;
 
-  if (*itsMaxUndoLevelPtr <= 0)
-    return false;
+  if (*itsMaxUndoLevelPtr <= 0) return false;
 
-  if (*itsCurrentUndoLevelPtr == *itsMaxUndoLevelPtr - 1)
-    RearrangeUndoTable();
+  if (*itsCurrentUndoLevelPtr == *itsMaxUndoLevelPtr - 1) RearrangeUndoTable();
 
   (*itsCurrentUndoLevelPtr)++;
   theRawData.Backup(itsUndoTable[*itsCurrentUndoLevelPtr]);
@@ -96,8 +91,7 @@ bool NFmiUndoRedoQData::SnapShotData(
 
 void NFmiUndoRedoQData::RearrangeUndoTable(void)
 {
-  if (itsCurrentUndoLevelPtr == 0)
-    return;
+  if (itsCurrentUndoLevelPtr == 0) return;
   char *undoTmp = itsUndoTable[0];
   std::string undoTmpText = itsUndoTextTable[0];
 
@@ -120,8 +114,7 @@ void NFmiUndoRedoQData::RearrangeUndoTable(void)
 
 bool NFmiUndoRedoQData::Undo(void)
 {
-  if (itsCurrentUndoLevelPtr == 0)
-    return false;
+  if (itsCurrentUndoLevelPtr == 0) return false;
   if ((*itsCurrentUndoLevelPtr) < 0)
     return false;
   else
@@ -130,8 +123,7 @@ bool NFmiUndoRedoQData::Undo(void)
 
 bool NFmiUndoRedoQData::Redo(void)
 {
-  if (itsCurrentUndoLevelPtr == 0)
-    return false;
+  if (itsCurrentUndoLevelPtr == 0) return false;
   if ((*itsCurrentRedoLevelPtr) == (*itsCurrentUndoLevelPtr) ||
       (*itsCurrentRedoLevelPtr) == ((*itsCurrentUndoLevelPtr) + 1))
     return false;
@@ -142,10 +134,8 @@ bool NFmiUndoRedoQData::Redo(void)
 bool NFmiUndoRedoQData::UndoData(const NFmiHarmonizerBookKeepingData &theHarmonizerBookKeepingData,
                                  NFmiRawData &theRawData)
 {
-  if (itsCurrentUndoLevelPtr == 0)
-    return false;
-  if ((*itsCurrentUndoLevelPtr) < 0)
-    return false;
+  if (itsCurrentUndoLevelPtr == 0) return false;
+  if ((*itsCurrentUndoLevelPtr) < 0) return false;
   if ((*itsCurrentUndoLevelPtr) == (*itsCurrentRedoLevelPtr))
   {
     std::string action("");
@@ -163,8 +153,7 @@ bool NFmiUndoRedoQData::UndoData(const NFmiHarmonizerBookKeepingData &theHarmoni
 
 bool NFmiUndoRedoQData::RedoData(NFmiRawData &theRawData)
 {
-  if (itsCurrentUndoLevelPtr == 0)
-    return false;
+  if (itsCurrentUndoLevelPtr == 0) return false;
   if ((*itsCurrentUndoLevelPtr) == (*itsCurrentRedoLevelPtr) ||
       ((*itsCurrentUndoLevelPtr) + 1) == (*itsCurrentRedoLevelPtr))
     return false;
@@ -172,8 +161,7 @@ bool NFmiUndoRedoQData::RedoData(NFmiRawData &theRawData)
   {
     theRawData.Undo(itsUndoTable[*itsCurrentRedoLevelPtr]);
     (*itsCurrentUndoLevelPtr)++;
-    if ((*itsCurrentRedoLevelPtr) + 1 <= (*itsMaxRedoLevelPtr))
-      (*itsCurrentRedoLevelPtr)++;
+    if ((*itsCurrentRedoLevelPtr) + 1 <= (*itsMaxRedoLevelPtr)) (*itsCurrentRedoLevelPtr)++;
   }
   return true;
 }
@@ -216,8 +204,7 @@ void NFmiUndoRedoQData::UndoLevel(long theDepth,
 
         for (int level = 0; level < (*itsMaxUndoLevelPtr); level++)
         {
-          if (itsUndoTable[level])
-            delete[] itsUndoTable[level];
+          if (itsUndoTable[level]) delete[] itsUndoTable[level];
         }
         *itsMaxUndoLevelPtr = 0;
         delete[] itsUndoTable;

--- a/smarttools/NFmiUndoRedoQData.h
+++ b/smarttools/NFmiUndoRedoQData.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <deque>
 #include "NFmiHarmonizerBookKeepingData.h"
+#include <deque>
 
 class NFmiRawData;
 

--- a/smarttools/NFmiUndoableMultiLevelMask.cpp
+++ b/smarttools/NFmiUndoableMultiLevelMask.cpp
@@ -81,16 +81,13 @@ NFmiUndoableMultiLevelMask::~NFmiUndoableMultiLevelMask(void)
 //--------------------------------------------------------
 bool NFmiUndoableMultiLevelMask::SnapShotData(void)
 {
-  if (!itsMultiLevelMask || itsMaxUndoLevel <= 0)
-    return false;
+  if (!itsMultiLevelMask || itsMaxUndoLevel <= 0) return false;
 
-  if (itsCurrentUndoLevel == itsMaxUndoLevel - 1)
-    RearrangeUndoTable();
+  if (itsCurrentUndoLevel == itsMaxUndoLevel - 1) RearrangeUndoTable();
 
   itsCurrentUndoLevel++;
   NFmiPtrList<NFmiMultiLevelMask>::Iterator it = itsUndoList.Index(itsCurrentUndoLevel);
-  if (it.CurrentPtr() == 0)
-    return false;  // ei pitäisi mennä tähän, exceptionin paikka!
+  if (it.CurrentPtr() == 0) return false;  // ei pitäisi mennä tähän, exceptionin paikka!
   it.Current() = *itsMultiLevelMask;
   itsCurrentRedoLevel = itsCurrentUndoLevel;
   itsMaxRedoLevel = itsCurrentRedoLevel;
@@ -111,8 +108,7 @@ bool NFmiUndoableMultiLevelMask::SnapShotData(void)
 void NFmiUndoableMultiLevelMask::RearrangeUndoTable(void)
 {
   NFmiPtrList<NFmiMultiLevelMask>::Iterator it = itsUndoList.Index(1);  // 1 = 1. paikka listassa
-  if (it.CurrentPtr() == 0)
-    return;  // ei pitäisi mennä tähän, exceptionin paikka!
+  if (it.CurrentPtr() == 0) return;  // ei pitäisi mennä tähän, exceptionin paikka!
 
   NFmiMultiLevelMask* tempMask = it.CurrentPtr();
   it.Remove(false);  // false = ei tuhoa dataa
@@ -148,8 +144,7 @@ bool NFmiUndoableMultiLevelMask::Redo(void)
 //--------------------------------------------------------
 bool NFmiUndoableMultiLevelMask::UndoData(void)
 {
-  if (!itsMultiLevelMask || itsCurrentUndoLevel < 1)
-    return false;
+  if (!itsMultiLevelMask || itsCurrentUndoLevel < 1) return false;
   if (itsCurrentUndoLevel == itsCurrentRedoLevel)
   {
     SnapShotData();         // "Ottaa kuvan" undo-toimintoa edeltäneestä tilanteesta,
@@ -157,8 +152,7 @@ bool NFmiUndoableMultiLevelMask::UndoData(void)
   }
 
   NFmiPtrList<NFmiMultiLevelMask>::Iterator it = itsUndoList.Index(itsCurrentUndoLevel);
-  if (it.CurrentPtr() == 0)
-    return false;  // ei pitäisi mennä tähän, exceptionin paikka!
+  if (it.CurrentPtr() == 0) return false;  // ei pitäisi mennä tähän, exceptionin paikka!
   *itsMultiLevelMask = *it.CurrentPtr();
   itsCurrentUndoLevel--;
   itsCurrentRedoLevel = itsCurrentUndoLevel + 2;
@@ -175,13 +169,11 @@ bool NFmiUndoableMultiLevelMask::RedoData(void)
   else
   {
     NFmiPtrList<NFmiMultiLevelMask>::Iterator it = itsUndoList.Index(itsCurrentRedoLevel);
-    if (it.CurrentPtr() == 0)
-      return false;  // ei pitäisi mennä tähän, exceptionin paikka!
+    if (it.CurrentPtr() == 0) return false;  // ei pitäisi mennä tähän, exceptionin paikka!
     *itsMultiLevelMask = *it.CurrentPtr();
 
     itsCurrentUndoLevel++;
-    if (itsCurrentRedoLevel + 1 <= itsMaxRedoLevel)
-      itsCurrentRedoLevel++;
+    if (itsCurrentRedoLevel + 1 <= itsMaxRedoLevel) itsCurrentRedoLevel++;
   }
   return true;
 }
@@ -207,16 +199,14 @@ void NFmiUndoableMultiLevelMask::UndoLevel(int theNewUndoLevel)
 // Tämä asettaa halutun maskin, mutta ei tee undo/redo valmisteluja tai muuta.
 bool NFmiUndoableMultiLevelMask::Mask(const NFmiBitMask& theMask, unsigned long theMaskType)
 {
-  if (itsMultiLevelMask)
-    return itsMultiLevelMask->Mask(theMask, theMaskType);
+  if (itsMultiLevelMask) return itsMultiLevelMask->Mask(theMask, theMaskType);
 
   return false;
 }
 
 const NFmiBitMask& NFmiUndoableMultiLevelMask::Mask(unsigned long theMaskType) const
 {
-  if (itsMultiLevelMask)
-    return itsMultiLevelMask->Mask(theMaskType);
+  if (itsMultiLevelMask) return itsMultiLevelMask->Mask(theMaskType);
 
   throw std::runtime_error("Error in application - NFmiUndoableMultiLevelMask::Mask has no mask.");
 }

--- a/smarttools/NFmiUndoableMultiLevelMask.h
+++ b/smarttools/NFmiUndoableMultiLevelMask.h
@@ -65,4 +65,3 @@ class NFmiUndoableMultiLevelMask
   int itsCurrentUndoLevel;
   int itsCurrentRedoLevel;
 };
-

--- a/test/NFmiDrawParamTest.cpp
+++ b/test/NFmiDrawParamTest.cpp
@@ -1,26 +1,23 @@
 #include "NFmiDrawParam.h"
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <algorithm>
 
-#include <regression/tframe.h>
 #include <newbase/NFmiDataIdent.h>
-#include <newbase/NFmiLevel.h>
 #include <newbase/NFmiDataMatrix.h>
+#include <newbase/NFmiLevel.h>
+#include <regression/tframe.h>
 
-#include <boost/shared_ptr.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/shared_ptr.hpp>
 
 //! Protection against conflicts with global functions
 namespace NFmiDrawParamTest
 {
 const std::string className = "NFmiDrawParam";
 
-void printError(const std::string& msg)
-{
-  std::cerr << "\n\t" << className << " - " << msg << " ";
-}
+void printError(const std::string& msg) { std::cerr << "\n\t" << className << " - " << msg << " "; }
 
 void constructors()
 {
@@ -87,8 +84,7 @@ void readWrite()
 
     // Read data from a file
     SharedNFmiDrawParam drawParam(new NFmiDrawParam);
-    if (not drawParam->Init(inFilename))
-      TEST_FAILED("Initialization of NFmiDrawParam failed!");
+    if (not drawParam->Init(inFilename)) TEST_FAILED("Initialization of NFmiDrawParam failed!");
 
     // Write back to a temporary file
     std::ofstream outFStream(outFilename.c_str());
@@ -133,8 +129,7 @@ void generalData()
   try
   {
     dP.Param(param);
-    if (dP.Param().GetParamIdent() != dataIdent.GetParamIdent())
-      TEST_FAILED("Value is not 10");
+    if (dP.Param().GetParamIdent() != dataIdent.GetParamIdent()) TEST_FAILED("Value is not 10");
   }
   catch (...)
   {
@@ -145,8 +140,7 @@ void generalData()
   try
   {
     dP.Level(level);
-    if (dP.Level().LevelValue() != 5)
-      TEST_FAILED("Value is not 5");
+    if (dP.Level().LevelValue() != 5) TEST_FAILED("Value is not 5");
   }
   catch (...)
   {
@@ -157,8 +151,7 @@ void generalData()
   try
   {
     dP.ParameterAbbreviation("FooBar");
-    if (dP.ParameterAbbreviation() != "FooBar")
-      TEST_FAILED("Value is not FooBar");
+    if (dP.ParameterAbbreviation() != "FooBar") TEST_FAILED("Value is not FooBar");
   }
   catch (...)
   {
@@ -168,8 +161,7 @@ void generalData()
   try
   {
     dP.InitFileName("FooBar.name");
-    if (dP.InitFileName() != "FooBar.name")
-      TEST_FAILED("Value is not FooBar.name");
+    if (dP.InitFileName() != "FooBar.name") TEST_FAILED("Value is not FooBar.name");
   }
   catch (...)
   {
@@ -180,8 +172,7 @@ void generalData()
   try
   {
     dP.MacroParamRelativePath("/fOO/Bar");
-    if (dP.MacroParamRelativePath() != "/fOO/Bar")
-      TEST_FAILED("Value is not /fOO/Bar");
+    if (dP.MacroParamRelativePath() != "/fOO/Bar") TEST_FAILED("Value is not /fOO/Bar");
   }
   catch (...)
   {
@@ -191,8 +182,7 @@ void generalData()
 
   try
   {
-    if (dP.FileVersionNumber() != 3.0)
-      TEST_FAILED("Value is not 3.0");
+    if (dP.FileVersionNumber() != 3.0) TEST_FAILED("Value is not 3.0");
   }
   catch (...)
   {
@@ -203,8 +193,7 @@ void generalData()
   try
   {
     dP.EditParam(true);
-    if (not dP.IsParamEdited())
-      TEST_FAILED("It is not edited");
+    if (not dP.IsParamEdited()) TEST_FAILED("It is not edited");
   }
   catch (...)
   {
@@ -215,8 +204,7 @@ void generalData()
   try
   {
     dP.Unit("ug/m2");
-    if (dP.Unit() != "ug/m2")
-      TEST_FAILED("Value is not ug/m2");
+    if (dP.Unit() != "ug/m2") TEST_FAILED("Value is not ug/m2");
   }
   catch (...)
   {
@@ -227,8 +215,7 @@ void generalData()
   try
   {
     dP.Activate(true);
-    if (not dP.IsActive())
-      TEST_FAILED("It is not active");
+    if (not dP.IsActive()) TEST_FAILED("It is not active");
   }
   catch (...)
   {
@@ -251,8 +238,7 @@ void generalData()
   try
   {
     dP.ViewMacroDrawParam(true);
-    if (not dP.ViewMacroDrawParam())
-      TEST_FAILED("It is not ViewMacroDrawParam");
+    if (not dP.ViewMacroDrawParam()) TEST_FAILED("It is not ViewMacroDrawParam");
   }
   catch (...)
   {
@@ -263,8 +249,7 @@ void generalData()
   try
   {
     dP.BorrowedParam(true);
-    if (not dP.BorrowedParam())
-      TEST_FAILED("It is not BorrowedParam");
+    if (not dP.BorrowedParam()) TEST_FAILED("It is not BorrowedParam");
   }
   catch (...)
   {
@@ -288,8 +273,7 @@ void generalData()
   try
   {
     dP.ModelRunIndex(1);
-    if (dP.ModelRunIndex() != 1)
-      TEST_FAILED("Value is not 1");
+    if (dP.ModelRunIndex() != 1) TEST_FAILED("Value is not 1");
   }
   catch (...)
   {
@@ -300,8 +284,7 @@ void generalData()
   try
   {
     dP.ModelOriginTimeCalculated(metTime);
-    if (dP.ModelOriginTimeCalculated() != metTime)
-      TEST_FAILED("Value is not correct");
+    if (dP.ModelOriginTimeCalculated() != metTime) TEST_FAILED("Value is not correct");
   }
   catch (...)
   {
@@ -312,8 +295,7 @@ void generalData()
   try
   {
     dP.TimeSerialModelRunCount(2);
-    if (dP.TimeSerialModelRunCount() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.TimeSerialModelRunCount() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -324,8 +306,7 @@ void generalData()
   try
   {
     dP.ModelRunDifferenceIndex(3);
-    if (dP.ModelRunDifferenceIndex() != 3)
-      TEST_FAILED("Value is not 3");
+    if (dP.ModelRunDifferenceIndex() != 3) TEST_FAILED("Value is not 3");
   }
   catch (...)
   {
@@ -336,8 +317,7 @@ void generalData()
   try
   {
     dP.DataComparisonProdId(1);
-    if (dP.DataComparisonProdId() != 1)
-      TEST_FAILED("Value is not 1");
+    if (dP.DataComparisonProdId() != 1) TEST_FAILED("Value is not 1");
   }
   catch (...)
   {
@@ -385,8 +365,7 @@ void generalVisualization()
   {
     const int style = 2;
     dP.GridDataPresentationStyle(style);
-    if (dP.GridDataPresentationStyle() != style)
-      TEST_FAILED("Value is not 2");
+    if (dP.GridDataPresentationStyle() != style) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -397,8 +376,7 @@ void generalVisualization()
   try
   {
     dP.UseIsoLineFeathering(true);
-    if (not dP.UseIsoLineFeathering())
-      TEST_FAILED("Is not enabled");
+    if (not dP.UseIsoLineFeathering()) TEST_FAILED("Is not enabled");
   }
   catch (...)
   {
@@ -409,8 +387,7 @@ void generalVisualization()
   try
   {
     dP.UseSimpleIsoLineDefinitions(true);
-    if (not dP.UseSimpleIsoLineDefinitions())
-      TEST_FAILED("Is not enabled");
+    if (not dP.UseSimpleIsoLineDefinitions()) TEST_FAILED("Is not enabled");
   }
   catch (...)
   {
@@ -421,8 +398,7 @@ void generalVisualization()
   try
   {
     dP.UseSimpleContourDefinitions(true);
-    if (not dP.UseSimpleContourDefinitions())
-      TEST_FAILED("Is not enabled");
+    if (not dP.UseSimpleContourDefinitions()) TEST_FAILED("Is not enabled");
   }
   catch (...)
   {
@@ -433,8 +409,7 @@ void generalVisualization()
   try
   {
     dP.UseSeparatorLinesBetweenColorContourClasses(true);
-    if (not dP.UseSeparatorLinesBetweenColorContourClasses())
-      TEST_FAILED("Is not enabled");
+    if (not dP.UseSeparatorLinesBetweenColorContourClasses()) TEST_FAILED("Is not enabled");
   }
   catch (...)
   {
@@ -445,8 +420,7 @@ void generalVisualization()
   try
   {
     dP.SimpleIsoLineZeroValue(-1);
-    if (dP.SimpleIsoLineZeroValue() != -1)
-      TEST_FAILED("Value is not -1");
+    if (dP.SimpleIsoLineZeroValue() != -1) TEST_FAILED("Value is not -1");
   }
   catch (...)
   {
@@ -457,8 +431,7 @@ void generalVisualization()
   try
   {
     dP.IsoLineSplineSmoothingFactor(2);
-    if (dP.IsoLineSplineSmoothingFactor() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.IsoLineSplineSmoothingFactor() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -469,8 +442,7 @@ void generalVisualization()
   try
   {
     dP.DrawOnlyOverMask(true);
-    if (not dP.DrawOnlyOverMask())
-      TEST_FAILED("Is not enabled");
+    if (not dP.DrawOnlyOverMask()) TEST_FAILED("Is not enabled");
   }
   catch (...)
   {
@@ -481,8 +453,7 @@ void generalVisualization()
   try
   {
     dP.UseCustomColorContouring(true);
-    if (not dP.UseCustomColorContouring())
-      TEST_FAILED("Is not enabled");
+    if (not dP.UseCustomColorContouring()) TEST_FAILED("Is not enabled");
   }
   catch (...)
   {
@@ -493,8 +464,7 @@ void generalVisualization()
   try
   {
     dP.UseCustomIsoLineing(true);
-    if (not dP.UseCustomIsoLineing())
-      TEST_FAILED("Is not enabled");
+    if (not dP.UseCustomIsoLineing()) TEST_FAILED("Is not enabled");
   }
   catch (...)
   {
@@ -505,8 +475,7 @@ void generalVisualization()
   try
   {
     dP.Alpha(20.0);
-    if (dP.Alpha() != 20.0)
-      TEST_FAILED("Value is noe 20.0");
+    if (dP.Alpha() != 20.0) TEST_FAILED("Value is noe 20.0");
   }
   catch (...)
   {
@@ -517,8 +486,7 @@ void generalVisualization()
   try
   {
     dP.HideParam(true);
-    if (not dP.IsParamHidden())
-      TEST_FAILED("Is not hidden");
+    if (not dP.IsParamHidden()) TEST_FAILED("Is not hidden");
     dP.HideParam(false);
   }
   catch (...)
@@ -530,8 +498,7 @@ void generalVisualization()
   try
   {
     dP.ShowDifference(true);
-    if (not dP.ShowDifference())
-      TEST_FAILED("Does not show difference");
+    if (not dP.ShowDifference()) TEST_FAILED("Does not show difference");
     dP.ShowDifference(false);
   }
   catch (...)
@@ -543,8 +510,7 @@ void generalVisualization()
   try
   {
     dP.ShowDifferenceToOriginalData(true);
-    if (not dP.ShowDifferenceToOriginalData())
-      TEST_FAILED("Does not show difference");
+    if (not dP.ShowDifferenceToOriginalData()) TEST_FAILED("Does not show difference");
     dP.ShowDifferenceToOriginalData(false);
   }
   catch (...)
@@ -569,8 +535,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.IsolineLabelBoxFillColor(color);
-    if (dP.IsolineLabelBoxFillColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.IsolineLabelBoxFillColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -582,8 +547,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.ContourLabelBoxFillColor(color);
-    if (dP.ContourLabelBoxFillColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.ContourLabelBoxFillColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -594,8 +558,7 @@ void simpleIsoline()
   try
   {
     dP.IsoLineGab(0.1);
-    if (dP.IsoLineGab() != 0.1)
-      TEST_FAILED("Value is not 0.1");
+    if (dP.IsoLineGab() != 0.1) TEST_FAILED("Value is not 0.1");
   }
   catch (...)
   {
@@ -607,8 +570,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.IsolineColor(color);
-    if (dP.IsolineColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.IsolineColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -620,8 +582,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.IsolineTextColor(color);
-    if (dP.IsolineTextColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.IsolineTextColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -632,8 +593,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineGap(0.1f);
-    if (dP.SimpleIsoLineGap() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.SimpleIsoLineGap() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -644,8 +604,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineLabelHeight(0.1f);
-    if (dP.SimpleIsoLineLabelHeight() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.SimpleIsoLineLabelHeight() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -656,8 +615,7 @@ void simpleIsoline()
   try
   {
     dP.ShowSimpleIsoLineLabelBox(true);
-    if (not dP.ShowSimpleIsoLineLabelBox())
-      TEST_FAILED("Is not enabled");
+    if (not dP.ShowSimpleIsoLineLabelBox()) TEST_FAILED("Is not enabled");
     dP.ShowSimpleIsoLineLabelBox(false);
   }
   catch (...)
@@ -669,8 +627,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineWidth(0.1f);
-    if (dP.SimpleIsoLineWidth() != 0.1f)
-      TEST_FAILED("Value is not 0.1");
+    if (dP.SimpleIsoLineWidth() != 0.1f) TEST_FAILED("Value is not 0.1");
   }
   catch (...)
   {
@@ -681,8 +638,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineLineStyle(2);
-    if (dP.SimpleIsoLineLineStyle() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.SimpleIsoLineLineStyle() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -693,8 +649,7 @@ void simpleIsoline()
   try
   {
     dP.UseSingleColorsWithSimpleIsoLines(true);
-    if (not dP.UseSingleColorsWithSimpleIsoLines())
-      TEST_FAILED("Value is not enebled");
+    if (not dP.UseSingleColorsWithSimpleIsoLines()) TEST_FAILED("Value is not enebled");
     dP.UseSingleColorsWithSimpleIsoLines(false);
   }
   catch (...)
@@ -706,8 +661,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineColorShadeLowValue(0.1f);
-    if (dP.SimpleIsoLineColorShadeLowValue() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.SimpleIsoLineColorShadeLowValue() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -718,8 +672,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineColorShadeMidValue(0.2f);
-    if (dP.SimpleIsoLineColorShadeMidValue() != 0.2f)
-      TEST_FAILED("Value is not 0.2f");
+    if (dP.SimpleIsoLineColorShadeMidValue() != 0.2f) TEST_FAILED("Value is not 0.2f");
   }
   catch (...)
   {
@@ -730,8 +683,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineColorShadeHighValue(0.3f);
-    if (dP.SimpleIsoLineColorShadeHighValue() != 0.3f)
-      TEST_FAILED("Value is not 0.3f");
+    if (dP.SimpleIsoLineColorShadeHighValue() != 0.3f) TEST_FAILED("Value is not 0.3f");
   }
   catch (...)
   {
@@ -742,8 +694,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineColorShadeHigh2Value(0.2f);
-    if (dP.SimpleIsoLineColorShadeHigh2Value() != 0.2f)
-      TEST_FAILED("Value is not 0.2f");
+    if (dP.SimpleIsoLineColorShadeHigh2Value() != 0.2f) TEST_FAILED("Value is not 0.2f");
   }
   catch (...)
   {
@@ -755,8 +706,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.SimpleIsoLineColorShadeLowValueColor(color);
-    if (dP.SimpleIsoLineColorShadeLowValueColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.SimpleIsoLineColorShadeLowValueColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -768,8 +718,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.SimpleIsoLineColorShadeMidValueColor(color);
-    if (dP.SimpleIsoLineColorShadeMidValueColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.SimpleIsoLineColorShadeMidValueColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -781,8 +730,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.SimpleIsoLineColorShadeHighValueColor(color);
-    if (dP.SimpleIsoLineColorShadeHighValueColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.SimpleIsoLineColorShadeHighValueColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -794,8 +742,7 @@ void simpleIsoline()
   {
     NFmiColor color(1.0, 0.0, 0.0, 0.5);
     dP.SimpleIsoLineColorShadeHigh2ValueColor(color);
-    if (dP.SimpleIsoLineColorShadeHigh2ValueColor() != color)
-      TEST_FAILED("Color is not red");
+    if (dP.SimpleIsoLineColorShadeHigh2ValueColor() != color) TEST_FAILED("Color is not red");
   }
   catch (...)
   {
@@ -806,8 +753,7 @@ void simpleIsoline()
   try
   {
     dP.SimpleIsoLineColorShadeClassCount(3);
-    if (dP.SimpleIsoLineColorShadeClassCount() != 3)
-      TEST_FAILED("Value is not 3");
+    if (dP.SimpleIsoLineColorShadeClassCount() != 3) TEST_FAILED("Value is not 3");
   }
   catch (...)
   {
@@ -832,8 +778,7 @@ void simpleColorContour()
   try
   {
     dP.ContourGab(0.1);
-    if (dP.ContourGab() != 0.1)
-      TEST_FAILED("Value is not 0.1");
+    if (dP.ContourGab() != 0.1) TEST_FAILED("Value is not 0.1");
   }
   catch (...)
   {
@@ -844,8 +789,7 @@ void simpleColorContour()
   try
   {
     dP.ContourColor(color);
-    if (dP.ContourColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.ContourColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -856,8 +800,7 @@ void simpleColorContour()
   try
   {
     dP.SimpleContourWidth(0.1f);
-    if (dP.SimpleContourWidth() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.SimpleContourWidth() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -868,8 +811,7 @@ void simpleColorContour()
   try
   {
     dP.SimpleContourLineStyle(2);
-    if (dP.SimpleContourLineStyle() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.SimpleContourLineStyle() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -880,8 +822,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeLowValue(0.1f);
-    if (dP.ColorContouringColorShadeLowValue() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.ColorContouringColorShadeLowValue() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -892,8 +833,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeMidValue(0.1f);
-    if (dP.ColorContouringColorShadeMidValue() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.ColorContouringColorShadeMidValue() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -904,8 +844,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeHighValue(0.1f);
-    if (dP.ColorContouringColorShadeHighValue() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.ColorContouringColorShadeHighValue() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -916,8 +855,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeHigh2Value(0.1f);
-    if (dP.ColorContouringColorShadeHigh2Value() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.ColorContouringColorShadeHigh2Value() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -928,8 +866,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeLowValueColor(color);
-    if (dP.ColorContouringColorShadeLowValueColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.ColorContouringColorShadeLowValueColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -940,8 +877,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeMidValueColor(color);
-    if (dP.ColorContouringColorShadeMidValueColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.ColorContouringColorShadeMidValueColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -952,8 +888,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeHighValueColor(color);
-    if (dP.ColorContouringColorShadeHighValueColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.ColorContouringColorShadeHighValueColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -964,8 +899,7 @@ void simpleColorContour()
   try
   {
     dP.ColorContouringColorShadeHigh2ValueColor(color);
-    if (dP.ColorContouringColorShadeHigh2ValueColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.ColorContouringColorShadeHigh2ValueColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -994,8 +928,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialIsoLineValues(floatVector);
-    if (dP.SpecialIsoLineValues().at(2) != floatVector.at(2))
-      TEST_FAILED("Value is not 1.1f");
+    if (dP.SpecialIsoLineValues().at(2) != floatVector.at(2)) TEST_FAILED("Value is not 1.1f");
   }
   catch (...)
   {
@@ -1006,8 +939,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialContourValues(floatVector);
-    if (dP.SpecialContourValues().at(2) != floatVector.at(2))
-      TEST_FAILED("Value is not 1.1f");
+    if (dP.SpecialContourValues().at(2) != floatVector.at(2)) TEST_FAILED("Value is not 1.1f");
   }
   catch (...)
   {
@@ -1018,8 +950,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialIsoLineLabelHeight(floatVector);
-    if (dP.SpecialIsoLineLabelHeight().at(2) != floatVector.at(2))
-      TEST_FAILED("Value is not 1.1f");
+    if (dP.SpecialIsoLineLabelHeight().at(2) != floatVector.at(2)) TEST_FAILED("Value is not 1.1f");
   }
   catch (...)
   {
@@ -1030,8 +961,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialContourLabelHeight(floatVector);
-    if (dP.SpecialContourLabelHeight().at(2) != floatVector.at(2))
-      TEST_FAILED("Value is not 1.1f");
+    if (dP.SpecialContourLabelHeight().at(2) != floatVector.at(2)) TEST_FAILED("Value is not 1.1f");
   }
   catch (...)
   {
@@ -1042,8 +972,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialIsoLineWidth(floatVector);
-    if (dP.SpecialIsoLineWidth().at(2) != floatVector.at(2))
-      TEST_FAILED("Value is not 1.1f");
+    if (dP.SpecialIsoLineWidth().at(2) != floatVector.at(2)) TEST_FAILED("Value is not 1.1f");
   }
   catch (...)
   {
@@ -1054,8 +983,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialcontourWidth(floatVector);
-    if (dP.SpecialcontourWidth().at(2) != floatVector.at(2))
-      TEST_FAILED("Value is not 1.1f");
+    if (dP.SpecialcontourWidth().at(2) != floatVector.at(2)) TEST_FAILED("Value is not 1.1f");
   }
   catch (...)
   {
@@ -1071,8 +999,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialIsoLineStyle(intVector);
-    if (dP.SpecialIsoLineStyle().at(2) != intVector.at(2))
-      TEST_FAILED("Value is not 1");
+    if (dP.SpecialIsoLineStyle().at(2) != intVector.at(2)) TEST_FAILED("Value is not 1");
   }
   catch (...)
   {
@@ -1083,8 +1010,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialContourStyle(intVector);
-    if (dP.SpecialContourStyle().at(2) != intVector.at(2))
-      TEST_FAILED("Value is not 1");
+    if (dP.SpecialContourStyle().at(2) != intVector.at(2)) TEST_FAILED("Value is not 1");
   }
   catch (...)
   {
@@ -1095,8 +1021,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialIsoLineColorIndexies(intVector);
-    if (dP.SpecialIsoLineColorIndexies().at(2) != intVector.at(2))
-      TEST_FAILED("Value is not 1");
+    if (dP.SpecialIsoLineColorIndexies().at(2) != intVector.at(2)) TEST_FAILED("Value is not 1");
   }
   catch (...)
   {
@@ -1107,8 +1032,7 @@ void customIsoline()
   try
   {
     dP.SetSpecialContourColorIndexies(intVector);
-    if (dP.SpecialContourColorIndexies().at(2) != intVector.at(2))
-      TEST_FAILED("Value is not 1");
+    if (dP.SpecialContourColorIndexies().at(2) != intVector.at(2)) TEST_FAILED("Value is not 1");
   }
   catch (...)
   {
@@ -1150,8 +1074,7 @@ void customColorContour()
   try
   {
     dP.UseIsoLineGabWithCustomContours(true);
-    if (not dP.UseIsoLineGabWithCustomContours())
-      TEST_FAILED("Value is not true");
+    if (not dP.UseIsoLineGabWithCustomContours()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1162,8 +1085,7 @@ void customColorContour()
   try
   {
     dP.UseContourGabWithCustomContours(true);
-    if (not dP.UseContourGabWithCustomContours())
-      TEST_FAILED("Value is not true");
+    if (not dP.UseContourGabWithCustomContours()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1179,8 +1101,7 @@ void customColorContour()
   try
   {
     dP.SetSpecialColorContouringValues(floatVector);
-    if (dP.SpecialColorContouringValues().at(2) != 1.1f)
-      TEST_FAILED("Value is not 1.1f");
+    if (dP.SpecialColorContouringValues().at(2) != 1.1f) TEST_FAILED("Value is not 1.1f");
   }
   catch (...)
   {
@@ -1196,8 +1117,7 @@ void customColorContour()
   try
   {
     dP.SpecialColorContouringColorIndexies(intVector);
-    if (dP.SpecialColorContouringColorIndexies().at(2) != 1)
-      TEST_FAILED("Value is not 1");
+    if (dP.SpecialColorContouringColorIndexies().at(2) != 1) TEST_FAILED("Value is not 1");
   }
   catch (...)
   {
@@ -1222,8 +1142,7 @@ void symbolSettings()
   try
   {
     dP.StationDataViewType(stationDataViewType);
-    if (dP.StationDataViewType() != stationDataViewType)
-      TEST_FAILED("Value is not kFmiSymbolView");
+    if (dP.StationDataViewType() != stationDataViewType) TEST_FAILED("Value is not kFmiSymbolView");
   }
   catch (...)
   {
@@ -1234,8 +1153,7 @@ void symbolSettings()
   try
   {
     dP.FrameColor(color);
-    if (dP.FrameColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.FrameColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1246,8 +1164,7 @@ void symbolSettings()
   try
   {
     dP.FillColor(color);
-    if (dP.FillColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.FillColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1259,8 +1176,7 @@ void symbolSettings()
   {
     NFmiPoint symbolWidthAndHeight(0.5, 0.6);
     dP.RelativeSize(symbolWidthAndHeight);
-    if (dP.RelativeSize() != symbolWidthAndHeight)
-      TEST_FAILED("Value is not same as the input");
+    if (dP.RelativeSize() != symbolWidthAndHeight) TEST_FAILED("Value is not same as the input");
   }
   catch (...)
   {
@@ -1310,8 +1226,7 @@ void symbolSettings()
   try
   {
     dP.ShowNumbers(true);
-    if (not dP.ShowNumbers())
-      TEST_FAILED("Value is not true");
+    if (not dP.ShowNumbers()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1322,8 +1237,7 @@ void symbolSettings()
   try
   {
     dP.ShowMasks(true);
-    if (not dP.ShowMasks())
-      TEST_FAILED("Value is not true");
+    if (not dP.ShowMasks()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1334,8 +1248,7 @@ void symbolSettings()
   try
   {
     dP.ShowColors(true);
-    if (not dP.ShowColors())
-      TEST_FAILED("Value is not true");
+    if (not dP.ShowColors()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1346,8 +1259,7 @@ void symbolSettings()
   try
   {
     dP.ShowColoredNumbers(true);
-    if (not dP.ShowColoredNumbers())
-      TEST_FAILED("Value is not true");
+    if (not dP.ShowColoredNumbers()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1358,8 +1270,7 @@ void symbolSettings()
   try
   {
     dP.ZeroColorMean(true);
-    if (not dP.ZeroColorMean())
-      TEST_FAILED("Value is not true");
+    if (not dP.ZeroColorMean()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1370,8 +1281,7 @@ void symbolSettings()
   try
   {
     dP.StationSymbolColorShadeLowValue(0.1f);
-    if (dP.StationSymbolColorShadeLowValue() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.StationSymbolColorShadeLowValue() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -1382,8 +1292,7 @@ void symbolSettings()
   try
   {
     dP.StationSymbolColorShadeMidValue(0.1f);
-    if (dP.StationSymbolColorShadeMidValue() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.StationSymbolColorShadeMidValue() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -1394,8 +1303,7 @@ void symbolSettings()
   try
   {
     dP.StationSymbolColorShadeHighValue(0.1f);
-    if (dP.StationSymbolColorShadeHighValue() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.StationSymbolColorShadeHighValue() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -1406,8 +1314,7 @@ void symbolSettings()
   try
   {
     dP.StationSymbolColorShadeLowValueColor(color);
-    if (dP.StationSymbolColorShadeLowValueColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.StationSymbolColorShadeLowValueColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1418,8 +1325,7 @@ void symbolSettings()
   try
   {
     dP.StationSymbolColorShadeMidValueColor(color);
-    if (dP.StationSymbolColorShadeMidValueColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.StationSymbolColorShadeMidValueColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1430,8 +1336,7 @@ void symbolSettings()
   try
   {
     dP.StationSymbolColorShadeHighValueColor(color);
-    if (dP.StationSymbolColorShadeHighValueColor() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.StationSymbolColorShadeHighValueColor() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1442,8 +1347,7 @@ void symbolSettings()
   try
   {
     dP.StationSymbolColorShadeClassCount(2);
-    if (dP.StationSymbolColorShadeClassCount() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.StationSymbolColorShadeClassCount() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -1454,8 +1358,7 @@ void symbolSettings()
   try
   {
     dP.UseSymbolsInTextMode(true);
-    if (not dP.UseSymbolsInTextMode())
-      TEST_FAILED("Value is not true");
+    if (not dP.UseSymbolsInTextMode()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1466,8 +1369,7 @@ void symbolSettings()
   try
   {
     dP.UsedSymbolListIndex(2);
-    if (dP.UsedSymbolListIndex() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.UsedSymbolListIndex() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -1478,8 +1380,7 @@ void symbolSettings()
   try
   {
     dP.SymbolIndexingMapListIndex(2);
-    if (dP.SymbolIndexingMapListIndex() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.SymbolIndexingMapListIndex() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -1502,8 +1403,7 @@ void dataEditing()
   try
   {
     dP.ModifyingStep(2.1);
-    if (dP.ModifyingStep() != 2.1)
-      TEST_FAILED("Value is not 2.1");
+    if (dP.ModifyingStep() != 2.1) TEST_FAILED("Value is not 2.1");
   }
   catch (...)
   {
@@ -1514,8 +1414,7 @@ void dataEditing()
   try
   {
     dP.TimeSerialModifyingLimit(2.1);
-    if (dP.TimeSerialModifyingLimit() != 2.1)
-      TEST_FAILED("Value is not 2.1");
+    if (dP.TimeSerialModifyingLimit() != 2.1) TEST_FAILED("Value is not 2.1");
   }
   catch (...)
   {
@@ -1526,8 +1425,7 @@ void dataEditing()
   try
   {
     dP.AbsoluteMinValue(1.1);
-    if (dP.AbsoluteMinValue() != 1.1)
-      TEST_FAILED("Value is not 1.1");
+    if (dP.AbsoluteMinValue() != 1.1) TEST_FAILED("Value is not 1.1");
   }
   catch (...)
   {
@@ -1538,8 +1436,7 @@ void dataEditing()
   try
   {
     dP.AbsoluteMaxValue(3.1);
-    if (dP.AbsoluteMaxValue() != 3.1)
-      TEST_FAILED("Value is not 3.1");
+    if (dP.AbsoluteMaxValue() != 3.1) TEST_FAILED("Value is not 3.1");
   }
   catch (...)
   {
@@ -1550,8 +1447,7 @@ void dataEditing()
   try
   {
     dP.TimeSeriesScaleMin(0.1);
-    if (dP.TimeSeriesScaleMin() != 0.1)
-      TEST_FAILED("Value is not 0.1");
+    if (dP.TimeSeriesScaleMin() != 0.1) TEST_FAILED("Value is not 0.1");
   }
   catch (...)
   {
@@ -1562,8 +1458,7 @@ void dataEditing()
   try
   {
     dP.TimeSeriesScaleMax(3.1);
-    if (dP.TimeSeriesScaleMax() != 3.1)
-      TEST_FAILED("Value is not 3.1");
+    if (dP.TimeSeriesScaleMax() != 3.1) TEST_FAILED("Value is not 3.1");
   }
   catch (...)
   {
@@ -1588,8 +1483,7 @@ void hatchSettings()
   try
   {
     dP.UseWithIsoLineHatch1(true);
-    if (not dP.UseWithIsoLineHatch1())
-      TEST_FAILED("Value is not true");
+    if (not dP.UseWithIsoLineHatch1()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1600,8 +1494,7 @@ void hatchSettings()
   try
   {
     dP.DrawIsoLineHatchWithBorders1(true);
-    if (not dP.DrawIsoLineHatchWithBorders1())
-      TEST_FAILED("Value is not true");
+    if (not dP.DrawIsoLineHatchWithBorders1()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1612,8 +1505,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchLowValue1(0.1f);
-    if (dP.IsoLineHatchLowValue1() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.IsoLineHatchLowValue1() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -1624,8 +1516,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchHighValue1(0.2f);
-    if (dP.IsoLineHatchHighValue1() != 0.2f)
-      TEST_FAILED("Value is not 0.2f");
+    if (dP.IsoLineHatchHighValue1() != 0.2f) TEST_FAILED("Value is not 0.2f");
   }
   catch (...)
   {
@@ -1636,8 +1527,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchType1(2);
-    if (dP.IsoLineHatchType1() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.IsoLineHatchType1() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -1648,8 +1538,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchColor1(color);
-    if (dP.IsoLineHatchColor1() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.IsoLineHatchColor1() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1660,8 +1549,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchBorderColor1(color);
-    if (dP.IsoLineHatchBorderColor1() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.IsoLineHatchBorderColor1() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1672,8 +1560,7 @@ void hatchSettings()
   try
   {
     dP.UseWithIsoLineHatch2(true);
-    if (not dP.UseWithIsoLineHatch2())
-      TEST_FAILED("Value is not true");
+    if (not dP.UseWithIsoLineHatch2()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1684,8 +1571,7 @@ void hatchSettings()
   try
   {
     dP.DrawIsoLineHatchWithBorders2(true);
-    if (not dP.DrawIsoLineHatchWithBorders2())
-      TEST_FAILED("Value is not true");
+    if (not dP.DrawIsoLineHatchWithBorders2()) TEST_FAILED("Value is not true");
   }
   catch (...)
   {
@@ -1696,8 +1582,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchLowValue2(0.1f);
-    if (dP.IsoLineHatchLowValue2() != 0.1f)
-      TEST_FAILED("Value is not 0.1f");
+    if (dP.IsoLineHatchLowValue2() != 0.1f) TEST_FAILED("Value is not 0.1f");
   }
   catch (...)
   {
@@ -1708,8 +1593,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchHighValue2(0.2f);
-    if (dP.IsoLineHatchHighValue2() != 0.2f)
-      TEST_FAILED("Value is not 0.2f");
+    if (dP.IsoLineHatchHighValue2() != 0.2f) TEST_FAILED("Value is not 0.2f");
   }
   catch (...)
   {
@@ -1720,8 +1604,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchType2(2);
-    if (dP.IsoLineHatchType2() != 2)
-      TEST_FAILED("Value is not 2");
+    if (dP.IsoLineHatchType2() != 2) TEST_FAILED("Value is not 2");
   }
   catch (...)
   {
@@ -1732,8 +1615,7 @@ void hatchSettings()
   try
   {
     dP.IsoLineHatchColor2(color);
-    if (dP.IsoLineHatchColor2() != color)
-      TEST_FAILED("Value is not red");
+    if (dP.IsoLineHatchColor2() != color) TEST_FAILED("Value is not red");
   }
   catch (...)
   {
@@ -1744,9 +1626,7 @@ void hatchSettings()
   TEST_PASSED();
 }
 
-void init()
-{
-}
+void init() {}
 // ----------------------------------------------------------------------
 /*!
  * The actual test suite


### PR DESCRIPTION
The commit 9a358ef has changed the formatting rules of the project. The rules don't produce exactly the same result as before the change. So here is the newly formatted code. I hope this isn't break other developers code and the result is what was intended to be done with the rule change.